### PR TITLE
Add background image functionality to datasets

### DIFF
--- a/src/argus/core/__init__.py
+++ b/src/argus/core/__init__.py
@@ -1,5 +1,6 @@
 """Core dataset detection and handling."""
 
+from argus.core.background import add_background_to_coco, add_background_to_yolo
 from argus.core.base import Dataset
 from argus.core.coco import COCODataset
 from argus.core.split import split_coco_dataset, split_yolo_dataset
@@ -9,6 +10,8 @@ __all__ = [
     "Dataset",
     "YOLODataset",
     "COCODataset",
+    "add_background_to_coco",
+    "add_background_to_yolo",
     "split_coco_dataset",
     "split_yolo_dataset",
 ]

--- a/src/argus/core/background.py
+++ b/src/argus/core/background.py
@@ -1,0 +1,310 @@
+"""Utilities for adding background-only images to datasets."""
+
+from __future__ import annotations
+
+import json
+import random
+import shutil
+from pathlib import Path
+
+import cv2
+
+from argus.core.coco import COCODataset
+from argus.core.split import _compute_split_sizes
+from argus.core.yolo import YOLODataset
+
+_SPLITS = ("train", "val", "test")
+_IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".webp"}
+
+
+def _collect_source_images(source: Path) -> list[Path]:
+    """Collect all image files from a source path.
+
+    Args:
+        source: Path to a single image file or directory containing images.
+
+    Returns:
+        List of image file paths.
+
+    Raises:
+        ValueError: If source doesn't exist or contains no valid images.
+    """
+    if not source.exists():
+        raise ValueError(f"Source path does not exist: {source}")
+
+    if source.is_file():
+        if source.suffix.lower() not in _IMAGE_EXTENSIONS:
+            raise ValueError(f"Source file is not a supported image format: {source}")
+        return [source]
+
+    # Source is a directory
+    images = [
+        f for f in source.iterdir()
+        if f.is_file() and f.suffix.lower() in _IMAGE_EXTENSIONS
+    ]
+
+    if not images:
+        raise ValueError(f"No valid image files found in: {source}")
+
+    return sorted(images, key=lambda p: p.name)
+
+
+def _assign_images_to_splits(
+    images: list[Path],
+    available_splits: list[str],
+    ratios: tuple[float, float, float],
+    seed: int | None,
+) -> dict[str, list[Path]]:
+    """Assign images to splits based on ratios.
+
+    Args:
+        images: List of image paths to distribute.
+        available_splits: Splits available in the dataset (e.g., ["train", "val"]).
+        ratios: Target ratios for train/val/test.
+        seed: Random seed for shuffling. None for random.
+
+    Returns:
+        Dictionary mapping split name to list of image paths.
+    """
+    if not available_splits:
+        # Unsplit dataset - all images go to a single bucket
+        return {"unsplit": list(images)}
+
+    # Re-normalize ratios for available splits only
+    split_indices = {s: i for i, s in enumerate(_SPLITS)}
+    available_ratios = [ratios[split_indices[s]] for s in available_splits]
+    total_ratio = sum(available_ratios)
+
+    if total_ratio == 0:
+        # All available splits have 0 ratio - distribute evenly
+        normalized = tuple(1.0 / len(available_splits) for _ in available_splits)
+    else:
+        normalized = tuple(r / total_ratio for r in available_ratios)
+
+    # Build a full 3-tuple for _compute_split_sizes, zeroing out unavailable splits
+    full_ratios = [0.0, 0.0, 0.0]
+    for i, split in enumerate(available_splits):
+        full_ratios[split_indices[split]] = normalized[i]
+
+    sizes = _compute_split_sizes(len(images), tuple(full_ratios))
+
+    # Shuffle images
+    shuffled = list(images)
+    rng = random.Random(seed)
+    rng.shuffle(shuffled)
+
+    # Assign to splits
+    assignments: dict[str, list[Path]] = {}
+    start = 0
+    for split in _SPLITS:
+        count = sizes[split]
+        if count > 0:
+            assignments[split] = shuffled[start : start + count]
+            start += count
+
+    return assignments
+
+
+def add_background_to_yolo(
+    dataset: YOLODataset,
+    source: Path,
+    ratios: tuple[float, float, float],
+    seed: int | None = None,
+) -> dict[str, int]:
+    """Add background-only images to a YOLO dataset.
+
+    Copies images to the appropriate images/{split}/ directory and creates
+    empty .txt files in labels/{split}/.
+
+    Args:
+        dataset: Target YOLO dataset.
+        source: Path to image file or directory of images.
+        ratios: Train/val/test distribution ratios.
+        seed: Random seed for distribution.
+
+    Returns:
+        Dictionary mapping split name to count of images added.
+
+    Raises:
+        ValueError: If source is invalid or images already exist.
+    """
+    images = _collect_source_images(source)
+    available_splits = dataset.splits if dataset.splits else []
+    assignments = _assign_images_to_splits(images, available_splits, ratios, seed)
+
+    counts: dict[str, int] = {}
+    duplicates: list[str] = []
+
+    for split, split_images in assignments.items():
+        if split == "unsplit":
+            image_dir = dataset.path / "images"
+            label_dir = dataset.path / "labels"
+        else:
+            image_dir = dataset.path / "images" / split
+            label_dir = dataset.path / "labels" / split
+
+        # Ensure directories exist
+        image_dir.mkdir(parents=True, exist_ok=True)
+        label_dir.mkdir(parents=True, exist_ok=True)
+
+        added = 0
+        for img_path in split_images:
+            dest_image = image_dir / img_path.name
+            dest_label = label_dir / f"{img_path.stem}.txt"
+
+            # Check for duplicates
+            if dest_image.exists():
+                duplicates.append(str(img_path.name))
+                continue
+
+            # Copy image
+            shutil.copy2(img_path, dest_image)
+
+            # Create empty label file (background = no annotations)
+            dest_label.write_text("")
+
+            added += 1
+
+        counts[split] = added
+
+    if duplicates:
+        raise ValueError(
+            f"Skipped {len(duplicates)} duplicate(s): {', '.join(duplicates[:5])}"
+            + ("..." if len(duplicates) > 5 else "")
+        )
+
+    return counts
+
+
+def add_background_to_coco(
+    dataset: COCODataset,
+    source: Path,
+    ratios: tuple[float, float, float],
+    seed: int | None = None,
+) -> dict[str, int]:
+    """Add background-only images to a COCO dataset.
+
+    Copies images to the appropriate images/{split}/ directory and updates
+    the corresponding annotation JSON file with new image entries (no annotations).
+
+    Args:
+        dataset: Target COCO dataset.
+        source: Path to image file or directory of images.
+        ratios: Train/val/test distribution ratios.
+        seed: Random seed for distribution.
+
+    Returns:
+        Dictionary mapping split name to count of images added.
+
+    Raises:
+        ValueError: If source is invalid or images already exist.
+    """
+    images = _collect_source_images(source)
+    available_splits = dataset.splits if dataset.splits else []
+    assignments = _assign_images_to_splits(images, available_splits, ratios, seed)
+
+    # Build mapping of split -> annotation file
+    split_to_ann_file: dict[str, Path] = {}
+    for ann_file in dataset.annotation_files:
+        split = _get_coco_split_from_filename(ann_file.stem)
+        split_to_ann_file[split] = ann_file
+
+    counts: dict[str, int] = {}
+    duplicates: list[str] = []
+
+    for split, split_images in assignments.items():
+        if not split_images:
+            continue
+
+        # Find annotation file for this split
+        ann_file = split_to_ann_file.get(split)
+        if not ann_file:
+            # For unsplit, use first annotation file
+            ann_file = dataset.annotation_files[0] if dataset.annotation_files else None
+
+        if not ann_file or not ann_file.exists():
+            raise ValueError(f"No annotation file found for split '{split}'")
+
+        # Determine image directory
+        if split == "unsplit" or split not in dataset.splits:
+            image_dir = dataset.path / "images"
+        else:
+            image_dir = dataset.path / "images" / split
+            if not image_dir.exists():
+                # Fallback to flat images/
+                image_dir = dataset.path / "images"
+
+        image_dir.mkdir(parents=True, exist_ok=True)
+
+        # Load annotation data
+        with open(ann_file, encoding="utf-8") as f:
+            data = json.load(f)
+
+        existing_filenames = {img.get("file_name") for img in data.get("images", [])}
+        max_image_id = max(
+            (img.get("id", 0) for img in data.get("images", [])), default=0
+        )
+
+        added = 0
+        new_images = []
+
+        for img_path in split_images:
+            # Check for duplicates
+            if img_path.name in existing_filenames:
+                duplicates.append(str(img_path.name))
+                continue
+
+            dest_image = image_dir / img_path.name
+            if dest_image.exists():
+                duplicates.append(str(img_path.name))
+                continue
+
+            # Copy image
+            shutil.copy2(img_path, dest_image)
+
+            # Get image dimensions
+            img = cv2.imread(str(dest_image))
+            if img is None:
+                # Fallback dimensions if image can't be read
+                height, width = 0, 0
+            else:
+                height, width = img.shape[:2]
+
+            # Create new image entry
+            max_image_id += 1
+            new_images.append({
+                "id": max_image_id,
+                "file_name": img_path.name,
+                "width": width,
+                "height": height,
+            })
+
+            added += 1
+
+        # Update annotation file
+        if new_images:
+            data["images"] = data.get("images", []) + new_images
+            with open(ann_file, "w", encoding="utf-8") as f:
+                json.dump(data, f)
+
+        counts[split] = added
+
+    if duplicates:
+        raise ValueError(
+            f"Skipped {len(duplicates)} duplicate(s): {', '.join(duplicates[:5])}"
+            + ("..." if len(duplicates) > 5 else "")
+        )
+
+    return counts
+
+
+def _get_coco_split_from_filename(filename: str) -> str:
+    """Extract split name from annotation filename."""
+    name_lower = filename.lower()
+    if "train" in name_lower:
+        return "train"
+    elif "val" in name_lower:
+        return "val"
+    elif "test" in name_lower:
+        return "test"
+    return "unsplit"

--- a/tests/test_add_background_command.py
+++ b/tests/test_add_background_command.py
@@ -1,0 +1,407 @@
+"""Tests for the add-background command."""
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from argus.cli import app
+from argus.core import COCODataset, YOLODataset
+from argus.core.background import (
+    _assign_images_to_splits,
+    _collect_source_images,
+    add_background_to_coco,
+    add_background_to_yolo,
+)
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def background_images(tmp_path: Path) -> Path:
+    """Create a directory with fake background images."""
+    bg_dir = tmp_path / "backgrounds"
+    bg_dir.mkdir()
+
+    # Create 10 fake image files
+    for i in range(10):
+        (bg_dir / f"bg_{i:03d}.jpg").write_bytes(b"fake image data")
+
+    return bg_dir
+
+
+@pytest.fixture
+def single_background_image(tmp_path: Path) -> Path:
+    """Create a single fake background image."""
+    img_path = tmp_path / "single_bg.png"
+    img_path.write_bytes(b"fake image data")
+    return img_path
+
+
+@pytest.fixture
+def yolo_split_dataset(tmp_path: Path) -> Path:
+    """Create a YOLO dataset with train/val splits."""
+    dataset_path = tmp_path / "yolo_split"
+    dataset_path.mkdir()
+
+    yaml_content = """
+names:
+  0: object
+"""
+    (dataset_path / "data.yaml").write_text(yaml_content)
+
+    for split in ["train", "val"]:
+        (dataset_path / "images" / split).mkdir(parents=True)
+        (dataset_path / "labels" / split).mkdir(parents=True)
+        # Add one existing image per split
+        (dataset_path / "images" / split / f"existing_{split}.jpg").write_bytes(
+            b"fake"
+        )
+        (dataset_path / "labels" / split / f"existing_{split}.txt").write_text(
+            "0 0.5 0.5 0.2 0.3\n"
+        )
+
+    return dataset_path
+
+
+@pytest.fixture
+def yolo_unsplit_dataset(tmp_path: Path) -> Path:
+    """Create a YOLO dataset without splits (flat structure)."""
+    dataset_path = tmp_path / "yolo_unsplit"
+    dataset_path.mkdir()
+
+    yaml_content = """
+names:
+  0: object
+"""
+    (dataset_path / "data.yaml").write_text(yaml_content)
+
+    (dataset_path / "images").mkdir()
+    (dataset_path / "labels").mkdir()
+
+    return dataset_path
+
+
+@pytest.fixture
+def coco_split_dataset(tmp_path: Path) -> Path:
+    """Create a COCO dataset with train/val splits."""
+    dataset_path = tmp_path / "coco_split"
+    dataset_path.mkdir()
+
+    annotations_dir = dataset_path / "annotations"
+    annotations_dir.mkdir()
+
+    for split in ["train", "val"]:
+        images_dir = dataset_path / "images" / split
+        images_dir.mkdir(parents=True)
+
+        coco_data = {
+            "images": [
+                {
+                    "id": 1,
+                    "file_name": f"existing_{split}.jpg",
+                    "width": 100,
+                    "height": 100,
+                }
+            ],
+            "annotations": [
+                {"id": 1, "image_id": 1, "category_id": 1, "bbox": [0, 0, 50, 50]}
+            ],
+            "categories": [{"id": 1, "name": "object"}],
+        }
+        (annotations_dir / f"instances_{split}.json").write_text(json.dumps(coco_data))
+        (images_dir / f"existing_{split}.jpg").write_bytes(b"fake")
+
+    return dataset_path
+
+
+class TestCollectSourceImages:
+    """Tests for _collect_source_images helper."""
+
+    def test_collect_single_image(self, single_background_image: Path) -> None:
+        """Test collecting a single image file."""
+        images = _collect_source_images(single_background_image)
+        assert len(images) == 1
+        assert images[0] == single_background_image
+
+    def test_collect_directory(self, background_images: Path) -> None:
+        """Test collecting images from a directory."""
+        images = _collect_source_images(background_images)
+        assert len(images) == 10
+
+    def test_nonexistent_path_raises(self, tmp_path: Path) -> None:
+        """Test that nonexistent path raises ValueError."""
+        with pytest.raises(ValueError, match="does not exist"):
+            _collect_source_images(tmp_path / "nonexistent")
+
+    def test_invalid_extension_raises(self, tmp_path: Path) -> None:
+        """Test that non-image file raises ValueError."""
+        txt_file = tmp_path / "file.txt"
+        txt_file.write_text("not an image")
+        with pytest.raises(ValueError, match="not a supported image format"):
+            _collect_source_images(txt_file)
+
+    def test_empty_directory_raises(self, tmp_path: Path) -> None:
+        """Test that empty directory raises ValueError."""
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        with pytest.raises(ValueError, match="No valid image files found"):
+            _collect_source_images(empty_dir)
+
+
+class TestAssignImagesToSplits:
+    """Tests for _assign_images_to_splits helper."""
+
+    def test_distribute_to_train_val_test(self, background_images: Path) -> None:
+        """Test distribution across all three splits."""
+        images = list(background_images.glob("*.jpg"))
+        assignments = _assign_images_to_splits(
+            images, ["train", "val", "test"], (0.8, 0.1, 0.1), seed=42
+        )
+
+        total = sum(len(imgs) for imgs in assignments.values())
+        assert total == len(images)
+        assert "train" in assignments
+        assert len(assignments["train"]) == 8  # 80% of 10
+
+    def test_distribute_to_train_val_only(self, background_images: Path) -> None:
+        """Test distribution when only train/val exist."""
+        images = list(background_images.glob("*.jpg"))
+        assignments = _assign_images_to_splits(
+            images, ["train", "val"], (0.8, 0.1, 0.1), seed=42
+        )
+
+        total = sum(len(imgs) for imgs in assignments.values())
+        assert total == len(images)
+        # Ratios should be renormalized: 0.8/(0.8+0.1) = ~0.89, 0.1/(0.8+0.1) = ~0.11
+        assert "train" in assignments
+        assert "val" in assignments
+        assert "test" not in assignments
+
+    def test_unsplit_dataset(self, background_images: Path) -> None:
+        """Test all images go to unsplit when no splits available."""
+        images = list(background_images.glob("*.jpg"))
+        assignments = _assign_images_to_splits(images, [], (0.8, 0.1, 0.1), seed=42)
+
+        assert "unsplit" in assignments
+        assert len(assignments["unsplit"]) == len(images)
+
+    def test_seed_reproducibility(self, background_images: Path) -> None:
+        """Test that same seed produces same assignments."""
+        images = list(background_images.glob("*.jpg"))
+
+        assignments1 = _assign_images_to_splits(
+            images, ["train", "val", "test"], (0.8, 0.1, 0.1), seed=123
+        )
+        assignments2 = _assign_images_to_splits(
+            images, ["train", "val", "test"], (0.8, 0.1, 0.1), seed=123
+        )
+
+        assert assignments1 == assignments2
+
+
+class TestAddBackgroundToYolo:
+    """Tests for add_background_to_yolo function."""
+
+    def test_add_to_split_dataset(
+        self, yolo_split_dataset: Path, background_images: Path
+    ) -> None:
+        """Test adding backgrounds to a YOLO dataset with splits."""
+        dataset = YOLODataset.detect(yolo_split_dataset)
+        assert dataset is not None
+
+        counts = add_background_to_yolo(
+            dataset, background_images, (0.8, 0.1, 0.1), seed=42
+        )
+
+        total_added = sum(counts.values())
+        assert total_added == 10
+
+        # Check files were created
+        for split in ["train", "val"]:
+            image_dir = yolo_split_dataset / "images" / split
+            label_dir = yolo_split_dataset / "labels" / split
+
+            # Count background images (excluding existing)
+            bg_images = [f for f in image_dir.glob("bg_*.jpg")]
+            bg_labels = [f for f in label_dir.glob("bg_*.txt")]
+
+            assert len(bg_images) == len(bg_labels)
+
+            # Verify label files are empty (background)
+            for label_file in bg_labels:
+                assert label_file.read_text() == ""
+
+    def test_add_to_unsplit_dataset(
+        self, yolo_unsplit_dataset: Path, single_background_image: Path
+    ) -> None:
+        """Test adding background to unsplit YOLO dataset."""
+        dataset = YOLODataset.detect(yolo_unsplit_dataset)
+        assert dataset is not None
+
+        counts = add_background_to_yolo(
+            dataset, single_background_image, (0.8, 0.1, 0.1), seed=42
+        )
+
+        assert counts.get("unsplit", 0) == 1
+
+        # Check files in root images/labels
+        assert (yolo_unsplit_dataset / "images" / "single_bg.png").exists()
+        assert (yolo_unsplit_dataset / "labels" / "single_bg.txt").exists()
+        assert (yolo_unsplit_dataset / "labels" / "single_bg.txt").read_text() == ""
+
+    def test_duplicate_detection(
+        self, yolo_unsplit_dataset: Path, single_background_image: Path
+    ) -> None:
+        """Test that duplicates are detected and skipped."""
+        dataset = YOLODataset.detect(yolo_unsplit_dataset)
+        assert dataset is not None
+
+        # Add once
+        add_background_to_yolo(
+            dataset, single_background_image, (0.8, 0.1, 0.1), seed=42
+        )
+
+        # Adding again should raise about duplicates
+        with pytest.raises(ValueError, match="duplicate"):
+            add_background_to_yolo(
+                dataset, single_background_image, (0.8, 0.1, 0.1), seed=42
+            )
+
+
+class TestAddBackgroundToCoco:
+    """Tests for add_background_to_coco function."""
+
+    def test_add_to_split_dataset(
+        self, coco_split_dataset: Path, background_images: Path
+    ) -> None:
+        """Test adding backgrounds to a COCO dataset with splits."""
+        dataset = COCODataset.detect(coco_split_dataset)
+        assert dataset is not None
+
+        counts = add_background_to_coco(
+            dataset, background_images, (0.8, 0.1, 0.1), seed=42
+        )
+
+        total_added = sum(counts.values())
+        assert total_added == 10
+
+        # Check annotation files were updated
+        for split in ["train", "val"]:
+            ann_file = coco_split_dataset / "annotations" / f"instances_{split}.json"
+            with open(ann_file, encoding="utf-8") as f:
+                data = json.load(f)
+
+            # Should have more than 1 image now (1 existing + backgrounds)
+            bg_images = [
+                img for img in data["images"] if img["file_name"].startswith("bg_")
+            ]
+
+            # Background images should have no annotations
+            bg_image_ids = {img["id"] for img in bg_images}
+            bg_annotations = [
+                ann for ann in data["annotations"] if ann["image_id"] in bg_image_ids
+            ]
+            assert len(bg_annotations) == 0
+
+
+class TestAddBackgroundCommand:
+    """Tests for the CLI add-background command."""
+
+    def test_add_to_yolo_dataset(
+        self, yolo_split_dataset: Path, background_images: Path
+    ) -> None:
+        """Test CLI command with YOLO dataset."""
+        result = runner.invoke(
+            app,
+            [
+                "add-background",
+                "--dataset-path",
+                str(yolo_split_dataset),
+                "--source",
+                str(background_images),
+                "--ratio",
+                "0.8,0.1,0.1",
+                "--seed",
+                "42",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Added" in result.stdout
+        assert "background image" in result.stdout
+
+    def test_add_to_coco_dataset(
+        self, coco_split_dataset: Path, single_background_image: Path
+    ) -> None:
+        """Test CLI command with COCO dataset."""
+        result = runner.invoke(
+            app,
+            [
+                "add-background",
+                "--dataset-path",
+                str(coco_split_dataset),
+                "--source",
+                str(single_background_image),
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Added" in result.stdout
+
+    def test_invalid_source(self, yolo_split_dataset: Path, tmp_path: Path) -> None:
+        """Test CLI with nonexistent source."""
+        result = runner.invoke(
+            app,
+            [
+                "add-background",
+                "--dataset-path",
+                str(yolo_split_dataset),
+                "--source",
+                str(tmp_path / "nonexistent"),
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "does not exist" in result.stdout
+
+    def test_invalid_dataset(
+        self, tmp_path: Path, single_background_image: Path
+    ) -> None:
+        """Test CLI with invalid dataset path."""
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+
+        result = runner.invoke(
+            app,
+            [
+                "add-background",
+                "--dataset-path",
+                str(empty_dir),
+                "--source",
+                str(single_background_image),
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "No YOLO or COCO dataset found" in result.stdout
+
+    def test_invalid_ratio(
+        self, yolo_split_dataset: Path, single_background_image: Path
+    ) -> None:
+        """Test CLI with invalid ratio."""
+        result = runner.invoke(
+            app,
+            [
+                "add-background",
+                "--dataset-path",
+                str(yolo_split_dataset),
+                "--source",
+                str(single_background_image),
+                "--ratio",
+                "invalid",
+            ],
+        )
+
+        assert result.exit_code == 1


### PR DESCRIPTION
- Implemented CLI command to add background-only images to YOLO and COCO datasets.
- Created utility functions for image collection and assignment to dataset splits.
- Added tests for the new functionality, ensuring proper handling of images and duplicates.