### PR TITLE
fix: rename CLI command from argus to argus-cv

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# argus
+# argus-cv
 
 Vision AI dataset toolkit for working with YOLO and COCO datasets.
 
@@ -7,30 +7,30 @@ Vision AI dataset toolkit for working with YOLO and COCO datasets.
 ## Installation
 
 ```bash
-uvx argus
+uvx argus-cv
 ```
 
 ## Usage
 
 ```bash
 # List datasets in current directory
-uvx argus list
+uvx argus-cv list
 
 # List datasets in specific path
-uvx argus list --path /path/to/datasets
+uvx argus-cv list --path /path/to/datasets
 
 # Limit search depth
-uvx argus list --path . --max-depth 2
+uvx argus-cv list --path . --max-depth 2
 
 # Show instance statistics for a dataset
-uvx argus stats --dataset-path /path/to/dataset
+uvx argus-cv stats --dataset-path /path/to/dataset
 
 # Short form
-uvx argus stats -d /path/to/dataset
+uvx argus-cv stats -d /path/to/dataset
 
 # View annotations interactively
-uvx argus view -d /path/to/dataset --split val
+uvx argus-cv view -d /path/to/dataset --split val
 
 # Split an unsplit dataset into train/val/test
-uvx argus split -d /path/to/dataset -o /path/to/output -r 0.8,0.1,0.1
+uvx argus-cv split -d /path/to/dataset -o /path/to/output -r 0.8,0.1,0.1
 ```

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -5,7 +5,7 @@ Point Argus at a dataset root. It will detect YOLO or COCO automatically.
 ## 1. List datasets under a directory
 
 ```bash
-argus list --path /datasets
+argus-cv list --path /datasets
 ```
 
 You will get a table with format, task, classes, and splits.
@@ -13,7 +13,7 @@ You will get a table with format, task, classes, and splits.
 ## 2. Inspect class balance and background images
 
 ```bash
-argus stats -d /datasets/traffic
+argus-cv stats -d /datasets/traffic
 ```
 
 This prints per-class counts per split and a summary line with image totals.
@@ -21,7 +21,7 @@ This prints per-class counts per split and a summary line with image totals.
 ## 3. Visual inspection
 
 ```bash
-argus view -d /datasets/traffic --split val
+argus-cv view -d /datasets/traffic --split val
 ```
 
 Controls inside the viewer:
@@ -36,7 +36,7 @@ Controls inside the viewer:
 ## 4. Split an unsplit dataset
 
 ```bash
-argus split -d /datasets/traffic -o /datasets/traffic_splits -r 0.8,0.1,0.1
+argus-cv split -d /datasets/traffic -o /datasets/traffic_splits -r 0.8,0.1,0.1
 ```
 
 This writes the split dataset to the output path and prints counts for each

--- a/docs/guides/listing.md
+++ b/docs/guides/listing.md
@@ -1,11 +1,11 @@
 # Listing datasets
 
-Use `argus list` to scan a directory tree and discover datasets.
+Use `argus-cv list` to scan a directory tree and discover datasets.
 
 ## Basic listing
 
 ```bash
-argus list --path /datasets
+argus-cv list --path /datasets
 ```
 
 This prints a table showing:
@@ -19,7 +19,7 @@ This prints a table showing:
 ## Control scan depth
 
 ```bash
-argus list --path /datasets --max-depth 2
+argus-cv list --path /datasets --max-depth 2
 ```
 
 This keeps scans fast when you have many nested projects.

--- a/docs/guides/splitting.md
+++ b/docs/guides/splitting.md
@@ -1,11 +1,11 @@
 # Splitting datasets
 
-Use `argus split` to create train/val/test splits from an unsplit dataset.
+Use `argus-cv split` to create train/val/test splits from an unsplit dataset.
 
 ## Basic split
 
 ```bash
-argus split -d /datasets/animals -o /datasets/animals_splits
+argus-cv split -d /datasets/animals -o /datasets/animals_splits
 ```
 
 By default, Argus uses a 0.8/0.1/0.1 ratio and stratified sampling.
@@ -13,7 +13,7 @@ By default, Argus uses a 0.8/0.1/0.1 ratio and stratified sampling.
 ## Custom ratio
 
 ```bash
-argus split -d /datasets/animals -o /datasets/animals_splits -r 0.7,0.2,0.1
+argus-cv split -d /datasets/animals -o /datasets/animals_splits -r 0.7,0.2,0.1
 ```
 
 Ratios can sum to 1.0 or 100.
@@ -21,13 +21,13 @@ Ratios can sum to 1.0 or 100.
 ## Disable stratification
 
 ```bash
-argus split -d /datasets/animals -o /datasets/animals_splits --no-stratify
+argus-cv split -d /datasets/animals -o /datasets/animals_splits --no-stratify
 ```
 
 ## Set a seed for determinism
 
 ```bash
-argus split -d /datasets/animals -o /datasets/animals_splits --seed 7
+argus-cv split -d /datasets/animals -o /datasets/animals_splits --seed 7
 ```
 
 ## Output layout

--- a/docs/guides/stats.md
+++ b/docs/guides/stats.md
@@ -1,11 +1,11 @@
 # Stats and counts
 
-`argus stats` provides per-class instance counts and image totals by split.
+`argus-cv stats` provides per-class instance counts and image totals by split.
 
 ## Example
 
 ```bash
-argus stats -d /datasets/retail
+argus-cv stats -d /datasets/retail
 ```
 
 Argus prints a table by class and split. It also includes a summary with:

--- a/docs/guides/viewer.md
+++ b/docs/guides/viewer.md
@@ -5,13 +5,13 @@ The viewer overlays boxes and masks for quick spot checks.
 ## Launching the viewer
 
 ```bash
-argus view -d /datasets/retail
+argus-cv view -d /datasets/retail
 ```
 
 ### View a specific split
 
 ```bash
-argus view -d /datasets/retail --split val
+argus-cv view -d /datasets/retail --split val
 ```
 
 ## Controls

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,13 +15,13 @@
 
 ```bash
 # Discover datasets
-argus list --path /data
+argus-cv list --path /data
 
 # Instant class stats
-argus stats -d /data/animals
+argus-cv stats -d /data/animals
 
 # Visual inspection
-argus view -d /data/animals --split val
+argus-cv view -d /data/animals --split val
 ```
 
   </div>
@@ -51,20 +51,20 @@ argus view -d /data/animals --split val
 === "Quick scan"
 
     ```bash
-    argus list --path /datasets
-    argus stats -d /datasets/retail
+    argus-cv list --path /datasets
+    argus-cv stats -d /datasets/retail
     ```
 
 === "Find label issues"
 
     ```bash
-    argus view -d /datasets/retail --split val
+    argus-cv view -d /datasets/retail --split val
     ```
 
 === "Create splits"
 
     ```bash
-    argus split -d /datasets/retail -o /datasets/retail_splits -r 0.8,0.1,0.1
+    argus-cv split -d /datasets/retail -o /datasets/retail_splits -r 0.8,0.1,0.1
     ```
 
 ## What Argus expects

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -13,7 +13,7 @@ Argus uses subcommands: `list`, `stats`, `view`, and `split`.
 Scan a directory tree and report detected datasets.
 
 ```bash
-argus list --path . --max-depth 3
+argus-cv list --path . --max-depth 3
 ```
 
 Options:
@@ -26,7 +26,7 @@ Options:
 Show instance counts per class and per split.
 
 ```bash
-argus stats --dataset-path /datasets/retail
+argus-cv stats --dataset-path /datasets/retail
 ```
 
 Options:
@@ -38,7 +38,7 @@ Options:
 Launch an interactive annotation viewer.
 
 ```bash
-argus view --dataset-path /datasets/retail --split val
+argus-cv view --dataset-path /datasets/retail --split val
 ```
 
 Options:
@@ -51,7 +51,7 @@ Options:
 Create train/val/test splits from an unsplit dataset.
 
 ```bash
-argus split --dataset-path /datasets/animals \
+argus-cv split --dataset-path /datasets/animals \
   --output-path /datasets/animals_splits \
   --ratio 0.8,0.1,0.1 \
   --stratify \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ docs = [
 ]
 
 [project.scripts]
-argus = "argus.cli:app"
+argus-cv = "argus.cli:app"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
Match the CLI command name with the package name for consistency. Updated all references in README and documentation.