### PR TITLE
docs: document semantic mask dataset support and update CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # argus-cv
 
-Vision AI dataset toolkit for working with YOLO and COCO datasets.
+Vision AI dataset toolkit for working with YOLO, COCO, and semantic mask datasets.
 
 **[Documentation](https://pirnerjonas.github.io/argus/)**
 
@@ -9,6 +9,13 @@ Vision AI dataset toolkit for working with YOLO and COCO datasets.
 ```bash
 uvx argus-cv
 ```
+
+## Highlights
+
+- Detects YOLO, COCO, and folder-based semantic mask datasets.
+- Reports per-class stats (pixel coverage for mask datasets).
+- Interactive viewer with bounding boxes, polygons, or mask overlays.
+- Split unsplit YOLO/COCO datasets into train/val/test.
 
 ## Usage
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -6,7 +6,7 @@ workflow.
 ## Quick install with uv
 
 ```bash
-uvx argus
+uvx argus-cv
 ```
 
 `uvx` runs the package in an isolated environment and keeps it up to date.
@@ -14,19 +14,19 @@ uvx argus
 Verify it works:
 
 ```bash
-argus --help
+argus-cv --help
 ```
 
 ## pipx
 
 ```bash
-pipx install argus
+pipx install argus-cv
 ```
 
 Verify it works:
 
 ```bash
-argus --help
+argus-cv --help
 ```
 
 ## From source
@@ -40,7 +40,7 @@ pip install -e .
 Verify it works:
 
 ```bash
-argus --help
+argus-cv --help
 ```
 
 ## Requirements

--- a/docs/guides/datasets.md
+++ b/docs/guides/datasets.md
@@ -1,7 +1,7 @@
 # Dataset formats
 
-Argus supports YOLO and COCO datasets. Detection and segmentation are handled
-out of the box.
+Argus supports YOLO, COCO, and folder-based semantic mask datasets. Detection
+and segmentation are handled out of the box.
 
 ## YOLO
 
@@ -58,6 +58,60 @@ dataset/
 
 If your annotation filenames include `train`, `val`, or `test`, Argus will treat
 those as splits. Otherwise it defaults to `train`.
+
+## Mask (semantic segmentation)
+
+Mask datasets are simple image + mask folders. Argus detects a few common
+patterns:
+
+- `images/` + `masks/`
+- `img/` + `gt/`
+- `leftImg8bit/` + `gtFine/` (Cityscapes-style)
+
+Split-aware layout:
+
+```text
+dataset/
+├── images/
+│   ├── train/
+│   └── val/
+├── masks/
+│   ├── train/
+│   └── val/
+└── classes.yaml  # Optional for grayscale, required for RGB palette masks
+```
+
+Unsplit layout:
+
+```text
+dataset/
+├── images/
+├── masks/
+└── classes.yaml
+```
+
+### Mask encoding
+
+- Grayscale masks: each pixel value is the class ID. Argus will auto-detect
+  class IDs if no `classes.yaml` is provided.
+- RGB palette masks: each class maps to a color. A `classes.yaml` is required.
+- Mask files should be `.png` and match the image stem (e.g., `frame.png`), or
+  use common suffixes like `_mask`, `_gt`, or `_label`.
+
+Example `classes.yaml`:
+
+```yaml
+names:
+  - background
+  - road
+  - sidewalk
+ignore_index: 255
+palette:
+  - id: 0
+    name: background
+  - id: 1
+    name: road
+```
 
 ## Detection heuristics
 

--- a/docs/guides/listing.md
+++ b/docs/guides/listing.md
@@ -11,7 +11,7 @@ argus-cv list --path /datasets
 This prints a table showing:
 
 - Dataset path
-- Format (yolo or coco)
+- Format (yolo, coco, or mask)
 - Task (detection or segmentation)
 - Number of classes
 - Detected splits

--- a/docs/guides/stats.md
+++ b/docs/guides/stats.md
@@ -1,6 +1,8 @@
 # Stats and counts
 
 `argus-cv stats` provides per-class instance counts and image totals by split.
+For mask datasets, it reports pixel coverage and how many images contain each
+class.
 
 ## Example
 
@@ -25,3 +27,4 @@ If Argus prints "No annotations found", check:
 
 - YOLO: `labels/` exists and matches `images/`.
 - COCO: annotation JSON files are valid and contain `annotations`.
+- Mask: masks are `.png` files and match the image file names.

--- a/docs/guides/viewer.md
+++ b/docs/guides/viewer.md
@@ -1,6 +1,7 @@
 # Visual inspection
 
-The viewer overlays boxes and masks for quick spot checks.
+The viewer overlays boxes and masks for quick spot checks. For mask datasets,
+it blends the segmentation mask over the image.
 
 ## Launching the viewer
 
@@ -14,6 +15,12 @@ argus-cv view -d /datasets/retail
 argus-cv view -d /datasets/retail --split val
 ```
 
+### Adjust mask opacity
+
+```bash
+argus-cv view -d /datasets/roads --opacity 0.3
+```
+
 ## Controls
 
 - Right arrow or `N`: next image
@@ -22,6 +29,7 @@ argus-cv view -d /datasets/retail --split val
 - Drag: pan while zoomed
 - `R`: reset zoom
 - `Q` or `Esc`: quit
+- `T`: toggle annotations or mask overlay
 
 ## Notes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,9 @@
     <p class="hero__eyebrow">Argus</p>
     <h1>Vision AI dataset work, without the friction.</h1>
     <p>
-      Argus is a focused CLI for YOLO and COCO datasets. List datasets, inspect
-      class balance, view annotations, and split cleanly for training.
+      Argus is a focused CLI for YOLO, COCO, and semantic mask datasets. List
+      datasets, inspect class balance, view annotations, and split cleanly for
+      training.
     </p>
     <div class="hero__actions">
       <a class="md-button md-button--primary" href="getting-started/quickstart/">Get started</a>
@@ -30,7 +31,7 @@ argus-cv view -d /data/animals --split val
 <div class="grid cards">
   <div class="card">
     <h3>Format-aware</h3>
-    <p>Detects YOLO and COCO by structure and metadata, not guesses.</p>
+    <p>Detects YOLO, COCO, and mask datasets by structure and metadata.</p>
   </div>
   <div class="card">
     <h3>Readable statistics</h3>
@@ -38,7 +39,7 @@ argus-cv view -d /data/animals --split val
   </div>
   <div class="card">
     <h3>Annotation viewer</h3>
-    <p>Browse images with boxes and masks overlayed. Pan and zoom included.</p>
+    <p>Browse images with boxes, polygons, and mask overlays. Pan and zoom included.</p>
   </div>
   <div class="card">
     <h3>Clean splits</h3>

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -3,7 +3,7 @@
 ## Global
 
 ```bash
-argus --help
+argus-cv --help
 ```
 
 Argus uses subcommands: `list`, `stats`, `view`, and `split`.
@@ -45,6 +45,7 @@ Options:
 
 - `--dataset-path`, `-d`: dataset root path
 - `--split`, `-s`: split to view (train, val, test)
+- `--opacity`, `-o`: mask overlay opacity (mask datasets only)
 
 ## split
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Argus
-site_description: Vision AI dataset toolkit for YOLO and COCO datasets.
+site_description: Vision AI dataset toolkit for YOLO, COCO, and mask datasets.
 site_author: Argus
 site_url: https://pirnerjonas.github.io/argus/
 repo_name: pirnerjonas/argus


### PR DESCRIPTION
### Motivation
- Clarify and document new folder-based semantic mask (segmentation) dataset support already implemented in the codebase.
- Align user-facing references to the packaged CLI name (`argus-cv`) across installation and reference docs.
- Expose viewer options and dataset expectations so users can successfully use mask datasets and the interactive viewer.

### Description
- Updated `README.md` and `mkdocs.yml` to mention mask dataset support and adjust site metadata.
- Revised installation docs in `docs/getting-started/installation.md` and the CLI reference in `docs/reference/cli.md` to use `argus-cv` and added the `--opacity` (`-o`) option for mask overlays.
- Expanded `docs/guides/datasets.md` with mask dataset layout, encoding details, `classes.yaml` examples, and naming conventions, and updated `docs/guides/listing.md`, `docs/guides/stats.md`, `docs/guides/viewer.md`, and `docs/index.md` to reflect mask-aware behavior and viewer controls.

### Testing
- No automated tests were run because this change set is documentation-only.
- The documentation files were committed locally (`docs: refresh docs for mask datasets`).
- Manual lint/build of documentation was not performed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975cf0339e88331a825e723c991f5c6)