### PR TITLE
Remove --no-stratify option from split CLI

### DIFF
--- a/docs/guides/splitting.md
+++ b/docs/guides/splitting.md
@@ -8,7 +8,7 @@ Use `argus-cv split` to create train/val/test splits from an unsplit dataset.
 argus-cv split -d /datasets/animals -o /datasets/animals_splits
 ```
 
-By default, Argus uses a 0.8/0.1/0.1 ratio and stratified sampling.
+Argus uses a 0.8/0.1/0.1 ratio and stratified sampling by default.
 
 ## Custom ratio
 
@@ -17,12 +17,6 @@ argus-cv split -d /datasets/animals -o /datasets/animals_splits -r 0.7,0.2,0.1
 ```
 
 Ratios can sum to 1.0 or 100.
-
-## Disable stratification
-
-```bash
-argus-cv split -d /datasets/animals -o /datasets/animals_splits --no-stratify
-```
 
 ## Set a seed for determinism
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -55,7 +55,6 @@ Create train/val/test splits from an unsplit dataset.
 argus-cv split --dataset-path /datasets/animals \
   --output-path /datasets/animals_splits \
   --ratio 0.8,0.1,0.1 \
-  --stratify \
   --seed 42
 ```
 
@@ -64,5 +63,4 @@ Options:
 - `--dataset-path`, `-d`: dataset root path
 - `--output-path`, `-o`: output directory (default: "splits" inside dataset path)
 - `--ratio`, `-r`: train/val/test ratio (default: 0.8,0.1,0.1)
-- `--stratify/--no-stratify`: enable or disable stratified splitting (default: enabled)
 - `--seed`: random seed (default: 42)

--- a/src/argus/cli.py
+++ b/src/argus/cli.py
@@ -534,13 +534,6 @@ def split_dataset(
             help="Train/val/test ratio (e.g. 0.8,0.1,0.1).",
         ),
     ] = "0.8,0.1,0.1",
-    stratify: Annotated[
-        bool,
-        typer.Option(
-            "--stratify/--no-stratify",
-            help="Stratify by class distribution when splitting.",
-        ),
-    ] = True,
     seed: Annotated[
         int,
         typer.Option(
@@ -593,9 +586,7 @@ def split_dataset(
         ) as progress:
             progress.add_task("Creating YOLO splits...", total=None)
             try:
-                counts = split_yolo_dataset(
-                    dataset, output_path, ratios, stratify, seed
-                )
+                counts = split_yolo_dataset(dataset, output_path, ratios, True, seed)
             except ValueError as exc:
                 console.print(f"[red]Error: {exc}[/red]")
                 raise typer.Exit(1) from exc
@@ -628,7 +619,7 @@ def split_dataset(
                     annotation_file,
                     output_path,
                     ratios,
-                    stratify,
+                    True,
                     seed,
                 )
             except ValueError as exc:


### PR DESCRIPTION
### Motivation
- Simplify the `argus-cv split` UX by removing the `--stratify/--no-stratify` toggle and always performing stratified splitting.

### Description
- Removed the `stratify` parameter from `split_dataset` in `src/argus/cli.py` and now call `split_yolo_dataset` and `split_coco_dataset` with `True` for stratification, and updated `docs/guides/splitting.md` and `docs/reference/cli.md` to remove the `--no-stratify` usage and adjust wording.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975d55c06c08331bafe0935bb7f4175)