### PR TITLE
feat: support Roboflow COCO format and improve YOLO classification detection

### DIFF
--- a/docs/guides/datasets.md
+++ b/docs/guides/datasets.md
@@ -59,6 +59,26 @@ dataset/
 If your annotation filenames include `train`, `val`, or `test`, Argus will treat
 those as splits. Otherwise it defaults to `train`.
 
+### Roboflow COCO
+
+Argus also supports the Roboflow variant of COCO format, where annotations live
+inside split directories:
+
+```text
+dataset/
+├── train/
+│   ├── _annotations.coco.json
+│   └── *.jpg
+├── valid/
+│   ├── _annotations.coco.json
+│   └── *.jpg
+└── test/
+    ├── _annotations.coco.json
+    └── *.jpg
+```
+
+Splits are detected from directory names (`train`, `valid`/`val`, `test`).
+
 ## Mask (semantic segmentation)
 
 Mask datasets are simple image + mask folders. Argus detects a few common

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -696,6 +696,92 @@ def mask_dataset_missing_mask(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
+def roboflow_coco_dataset(tmp_path: Path) -> Path:
+    """Create a Roboflow COCO dataset with annotations in split directories.
+
+    Structure:
+        dataset/
+        ├── train/
+        │   ├── _annotations.coco.json
+        │   ├── img001.jpg
+        │   └── img002.jpg
+        ├── valid/
+        │   ├── _annotations.coco.json
+        │   └── img003.jpg
+        └── test/
+            ├── _annotations.coco.json
+            └── img004.jpg
+    """
+    dataset_path = tmp_path / "roboflow_coco"
+    dataset_path.mkdir()
+
+    # Create train split
+    train_dir = dataset_path / "train"
+    train_dir.mkdir()
+    train_coco = {
+        "info": {"description": "Roboflow train"},
+        "licenses": [],
+        "images": [
+            {"id": 1, "file_name": "img001.jpg", "width": 640, "height": 480},
+            {"id": 2, "file_name": "img002.jpg", "width": 640, "height": 480},
+        ],
+        "annotations": [
+            {"id": 1, "image_id": 1, "category_id": 1, "bbox": [100, 100, 50, 50]},
+            {"id": 2, "image_id": 2, "category_id": 2, "bbox": [200, 200, 60, 60]},
+        ],
+        "categories": [
+            {"id": 1, "name": "person", "supercategory": "human"},
+            {"id": 2, "name": "car", "supercategory": "vehicle"},
+        ],
+    }
+    (train_dir / "_annotations.coco.json").write_text(json.dumps(train_coco))
+    (train_dir / "img001.jpg").write_bytes(b"fake train image 1")
+    (train_dir / "img002.jpg").write_bytes(b"fake train image 2")
+
+    # Create valid split
+    valid_dir = dataset_path / "valid"
+    valid_dir.mkdir()
+    valid_coco = {
+        "info": {"description": "Roboflow valid"},
+        "licenses": [],
+        "images": [
+            {"id": 1, "file_name": "img003.jpg", "width": 640, "height": 480},
+        ],
+        "annotations": [
+            {"id": 1, "image_id": 1, "category_id": 1, "bbox": [150, 150, 40, 40]},
+        ],
+        "categories": [
+            {"id": 1, "name": "person", "supercategory": "human"},
+            {"id": 2, "name": "car", "supercategory": "vehicle"},
+        ],
+    }
+    (valid_dir / "_annotations.coco.json").write_text(json.dumps(valid_coco))
+    (valid_dir / "img003.jpg").write_bytes(b"fake valid image")
+
+    # Create test split
+    test_dir = dataset_path / "test"
+    test_dir.mkdir()
+    test_coco = {
+        "info": {"description": "Roboflow test"},
+        "licenses": [],
+        "images": [
+            {"id": 1, "file_name": "img004.jpg", "width": 640, "height": 480},
+        ],
+        "annotations": [
+            {"id": 1, "image_id": 1, "category_id": 2, "bbox": [50, 50, 30, 30]},
+        ],
+        "categories": [
+            {"id": 1, "name": "person", "supercategory": "human"},
+            {"id": 2, "name": "car", "supercategory": "vehicle"},
+        ],
+    }
+    (test_dir / "_annotations.coco.json").write_text(json.dumps(test_coco))
+    (test_dir / "img004.jpg").write_bytes(b"fake test image")
+
+    return dataset_path
+
+
+@pytest.fixture
 def mask_dataset_dimension_mismatch(tmp_path: Path) -> Path:
     """Create a mask dataset where image and mask have different dimensions.
 


### PR DESCRIPTION
## Summary

- Add support for Roboflow COCO format where annotations live inside split directories
- Fix false positive detection where Roboflow COCO datasets were detected as YOLO classification
- YOLO classification now rejects directories containing COCO annotation files

## Test plan

- [x] Added `roboflow_coco_dataset` test fixture
- [x] Added tests for Roboflow COCO detection, splits, and image paths
- [x] Added test to verify Roboflow COCO is not falsely detected as YOLO classification
- [x] Added test for YOLO classification rejecting directories with COCO JSON files
- [x] All 125 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)