### PR TITLE
fix: support Roboflow YOLO directory layout

### DIFF
--- a/docs/guides/datasets.md
+++ b/docs/guides/datasets.md
@@ -32,6 +32,31 @@ dataset/
 └── labels/
 ```
 
+### Roboflow YOLO
+
+Argus also supports the Roboflow variant of the YOLO format, where images and
+labels live inside split directories instead of under a top-level `images/` and
+`labels/` folder:
+
+```text
+dataset/
+├── data.yaml
+├── train/
+│   ├── images/
+│   └── labels/
+├── valid/
+│   ├── images/
+│   └── labels/
+└── test/
+    ├── images/
+    └── labels/
+```
+
+Roboflow uses `valid` instead of `val` for the validation split. Argus detects
+this automatically and normalises it to `val` internally. The `data.yaml` paths
+typically use `../train/images` style references — Argus handles these by
+falling back to filesystem probing when the relative paths do not resolve.
+
 Argus infers the task type by scanning a few label files:
 
 - 5 values per line: detection

--- a/docs/guides/filtering.md
+++ b/docs/guides/filtering.md
@@ -45,12 +45,15 @@ The filter command works with all dataset formats:
 | YOLO Detection | Yes | Labels remapped to new class IDs |
 | YOLO Segmentation | Yes | Polygon annotations preserved |
 | YOLO Classification | Yes | Only selected class directories copied |
+| YOLO (Roboflow layout) | Yes | Reads `{split}/images/` layout, writes standard layout |
 | COCO | Yes | Annotations and category IDs remapped |
 | Mask | Yes | Pixel values remapped to new class IDs |
 
 ## Output layout
 
-The output preserves the original dataset structure with train/val/test splits.
+The output always uses the standard dataset layout, even when the source uses a
+different directory structure (e.g. Roboflow YOLO). This normalises the output
+so it can be used directly with training frameworks.
 
 YOLO output:
 

--- a/docs/guides/stats.md
+++ b/docs/guides/stats.md
@@ -21,10 +21,18 @@ Argus prints a table by class and split. It also includes a summary with:
 Empty label files or images without annotations can skew training. Argus counts
 those so you can decide if you want to filter or re-label.
 
+## Roboflow YOLO datasets
+
+Roboflow exports YOLO datasets with a different directory layout
+(`{split}/images/` instead of `images/{split}/`). Argus detects this
+automatically — no extra flags needed. The `valid` directory is treated as the
+`val` split.
+
 ## Common problems
 
 If Argus prints "No annotations found", check:
 
-- YOLO: `labels/` exists and matches `images/`.
+- YOLO: `labels/` exists and matches `images/`. For Roboflow YOLO datasets,
+  labels should be at `{split}/labels/`.
 - COCO: annotation JSON files are valid and contain `annotations`.
 - Mask: masks are `.png` files and match the image file names.

--- a/src/argus/core/filter.py
+++ b/src/argus/core/filter.py
@@ -85,15 +85,13 @@ def _filter_yolo_detection_segmentation(
 
     # Collect all image/label pairs
     all_pairs: list[tuple[Path, Path, str]] = []
-    labels_root = dataset.path / "labels"
 
     for split in splits:
         if has_splits:
-            images_dir = dataset.path / "images" / split
-            labels_dir = labels_root / split
+            images_dir, labels_dir = dataset.get_split_dirs(split)
         else:
             images_dir = dataset.path / "images"
-            labels_dir = labels_root
+            labels_dir = dataset.path / "labels"
 
         if not images_dir.is_dir():
             continue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -782,6 +782,76 @@ def roboflow_coco_dataset(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
+def roboflow_yolo_dataset(tmp_path: Path) -> Path:
+    """Create a Roboflow YOLO dataset with {split}/images/ layout.
+
+    Structure:
+        dataset/
+        ├── data.yaml
+        ├── train/
+        │   ├── images/
+        │   │   ├── img001.jpg
+        │   │   └── img002.jpg
+        │   └── labels/
+        │       ├── img001.txt
+        │       └── img002.txt
+        ├── valid/
+        │   ├── images/
+        │   │   └── img003.jpg
+        │   └── labels/
+        │       └── img003.txt
+        └── test/
+            ├── images/
+            │   └── img004.jpg
+            └── labels/
+                └── img004.txt
+    """
+    dataset_path = tmp_path / "roboflow_yolo"
+    dataset_path.mkdir()
+
+    # Create data.yaml with Roboflow-style paths
+    yaml_content = (
+        "names:\n"
+        "- ball\n"
+        "- player\n"
+        "- referee\n"
+        "nc: 3\n"
+        "train: ../train/images\n"
+        "val: ../valid/images\n"
+        "test: ../test/images\n"
+    )
+    (dataset_path / "data.yaml").write_text(yaml_content)
+
+    # Train split
+    (dataset_path / "train" / "images").mkdir(parents=True)
+    (dataset_path / "train" / "labels").mkdir(parents=True)
+    (dataset_path / "train" / "images" / "img001.jpg").write_bytes(b"fake image")
+    (dataset_path / "train" / "images" / "img002.jpg").write_bytes(b"fake image")
+    (dataset_path / "train" / "labels" / "img001.txt").write_text(
+        "0 0.5 0.5 0.1 0.1\n1 0.3 0.3 0.2 0.4\n"
+    )
+    (dataset_path / "train" / "labels" / "img002.txt").write_text(
+        "0 0.6 0.6 0.15 0.15\n"
+    )
+
+    # Valid split (Roboflow uses "valid" instead of "val")
+    (dataset_path / "valid" / "images").mkdir(parents=True)
+    (dataset_path / "valid" / "labels").mkdir(parents=True)
+    (dataset_path / "valid" / "images" / "img003.jpg").write_bytes(b"fake image")
+    (dataset_path / "valid" / "labels" / "img003.txt").write_text(
+        "1 0.4 0.4 0.2 0.3\n2 0.7 0.7 0.1 0.1\n"
+    )
+
+    # Test split
+    (dataset_path / "test" / "images").mkdir(parents=True)
+    (dataset_path / "test" / "labels").mkdir(parents=True)
+    (dataset_path / "test" / "images" / "img004.jpg").write_bytes(b"fake image")
+    (dataset_path / "test" / "labels" / "img004.txt").write_text("")
+
+    return dataset_path
+
+
+@pytest.fixture
 def mask_dataset_dimension_mismatch(tmp_path: Path) -> Path:
     """Create a mask dataset where image and mask have different dimensions.
 


### PR DESCRIPTION
## Summary

- Add Roboflow YOLO layout detection (`{split}/images/` instead of `images/{split}/`) with `_roboflow_layout` field and `get_split_dirs()` helper on `YOLODataset`
- Fix `_detect_splits` to handle `valid` as alias for `val` and `../train/images` style config paths
- Fix `_determine_task_type`, `get_instance_counts`, `get_image_counts`, `get_image_paths`, and `_filter_yolo_detection_segmentation` to use layout-aware path resolution
- Filter output always uses standard YOLO layout regardless of input format
- Update docs for datasets, filtering, and stats guides

Closes #38

## Test plan

- [x] All 153 existing + new tests pass (`uv run pytest tests/`)
- [x] New tests cover: Roboflow layout detection, instance counts, image counts, image paths, single-class filter, no-background filter, CLI filter, CLI stats
- [x] Manual verification against `test_data/roboflow/padel-poyca-v9/yolov8/` with both `stats` and `filter` commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)