### PR TITLE
docs: add `convert` CLI command to reference

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -6,7 +6,7 @@
 argus-cv --help
 ```
 
-Argus uses subcommands: `list`, `stats`, `view`, and `split`.
+Argus uses subcommands: `list`, `stats`, `view`, `split`, and `convert`.
 
 ## list
 
@@ -64,3 +64,22 @@ Options:
 - `--output-path`, `-o`: output directory (default: "splits" inside dataset path)
 - `--ratio`, `-r`: train/val/test ratio (default: 0.8,0.1,0.1)
 - `--seed`: random seed (default: 42)
+
+## convert
+
+Convert a dataset from one format to another. Currently supports converting
+MaskDataset to YOLO segmentation format.
+
+```bash
+argus-cv convert --input-path /path/to/masks \
+  --output-path /path/to/output \
+  --to yolo-seg
+```
+
+Options:
+
+- `--input-path`, `-i`: source dataset path (default: ".")
+- `--output-path`, `-o`: output directory (default: "converted" next to the input path)
+- `--to`: target format (currently only `yolo-seg`)
+- `--epsilon-factor`, `-e`: polygon simplification factor (default: 0.005)
+- `--min-area`, `-a`: minimum contour area in pixels (default: 100.0)


### PR DESCRIPTION
### Motivation
- Ensure the CLI reference documents the newly exposed `convert` subcommand and that the global subcommand list matches available commands.

### Description
- Updated `docs/reference/cli.md` to include `convert` in the global subcommand list and added a `## convert` section with example usage and options (`--input-path`, `--output-path`, `--to`, `--epsilon-factor`, `--min-area`).

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985f37d15d88331ba96a3287d9c93cd)