### PR TITLE
Rename CLI to argus-cv

### DIFF
--- a/src/argus/__main__.py
+++ b/src/argus/__main__.py
@@ -1,4 +1,4 @@
-"""Entry point for python -m argus."""
+"""Entry point for python -m argus (argus-cv CLI)."""
 
 from argus.cli import app
 

--- a/src/argus/cli.py
+++ b/src/argus/cli.py
@@ -35,7 +35,7 @@ from argus.core.split import (
 console = Console()
 
 app = typer.Typer(
-    name="argus",
+    name="argus-cv",
     help="Vision AI dataset toolkit for working with YOLO and COCO datasets.",
     no_args_is_help=True,
 )


### PR DESCRIPTION
### Motivation
- Unify user-facing CLI branding so help text and docs match the installed command name (`argus-cv`) and avoid confusing discrepancies between Typer app name and `pyproject.toml`/documentation.

### Description
- Updated the Typer app name from `argus` to `argus-cv` in `src/argus/cli.py` so generated help and error output use the documented command name.
- Clarified the module docstring in `src/argus/__main__.py` to reference the `argus-cv` CLI.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985f9baea088331a69299f1903d58bd)