### PR TITLE
ci: rename lint job to checks and add commit-msg pre-commit hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,18 +9,19 @@ on:
       - main
 
 jobs:
-  lint:
+  checks:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: j178/prek-action@v1
+      - name: Run pre-commit checks
+        uses: j178/prek-action@v1
 
   test:
     runs-on: ubuntu-latest
-    needs: lint
+    needs: checks
     
     steps:
       - name: Checkout code

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,8 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v3.2.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]


### PR DESCRIPTION
### Motivation
- Make the CI job name reflect that it runs pre-commit checks (including commit-message checks) by renaming `lint` to `checks` rather than implying only linting.
- Enforce conventional commit messages by adding a commit-msg hook to the repository's pre-commit configuration.

### Description
- Rename the workflow job `lint` to `checks` in `.github/workflows/ci.yml` and update the `needs` dependency for the `test` job to `checks`.
- Add a descriptive step name `Run pre-commit checks` for the pre-commit action in `ci.yml`.
- Add the `conventional-pre-commit` hook to `.pre-commit-config.yaml` with `stages: [commit-msg]` to validate commit messages.

### Testing
- Ran `uv sync --only-group dev` locally to exercise the test setup, which failed due to a network error when fetching packages from PyPI.
- No further automated tests completed locally; the updated workflow will run `uv run pytest` in CI once network access is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986d4c63fac833191a0f20a412fbe37)