### PR TITLE
ci: add semantic PR title workflow

### DIFF
--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -1,0 +1,22 @@
+name: Semantic PR Title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+    branches:
+      - main
+
+jobs:
+  semantic-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Check PR title
+        uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation
- Ensure the main CI workflow uses GitHub's default `pull_request` triggers by removing the explicit `types` so no PR events are accidentally excluded.
- Run a dedicated semantic PR title check on PR lifecycle events to enforce title conventions across `opened`, `reopened`, `synchronize`, and `edited` events.

### Description
- Remove the `types` list under `pull_request` in `.github/workflows/ci.yml` so the workflow uses default triggers for PR activity. 
- Add `.github/workflows/semantic-pr-title.yml` to run `amannn/action-semantic-pull-request@v6` on `pull_request` events with `types` `opened`, `reopened`, `synchronize`, and `edited` targeting the `main` branch. 
- Grant `pull-requests: read` permission and provide `GITHUB_TOKEN` to the semantic PR title action in the new workflow.

### Testing
- No automated tests were run locally because these changes are CI workflow updates and will be validated when GitHub Actions executes the workflows on PR events.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987282f3dcc8331903f845d306d4616)