### PR TITLE
fix(view): match COCO images with path prefixes in file_name

### DIFF
--- a/src/argus/core/coco.py
+++ b/src/argus/core/coco.py
@@ -540,6 +540,23 @@ class COCODataset(Dataset):
 
         return sorted(image_paths, key=lambda p: p.name)
 
+    @staticmethod
+    def _match_image_entry(images: list, image_path: Path) -> dict | None:
+        """Find the image entry matching the given path.
+
+        Matches against the full ``file_name`` value first, then falls back
+        to comparing just the basename so that relative paths like
+        ``"images/foo.jpg"`` still match.
+        """
+        file_name = image_path.name
+        for img in images:
+            if not isinstance(img, dict):
+                continue
+            fn = img.get("file_name")
+            if fn == file_name or (isinstance(fn, str) and Path(fn).name == file_name):
+                return img
+        return None
+
     def get_annotations_for_image(self, image_path: Path) -> list[dict]:
         """Get annotations for a specific image.
 
@@ -550,7 +567,6 @@ class COCODataset(Dataset):
             List of annotation dicts with bbox/polygon in absolute coordinates.
         """
         annotations: list[dict] = []
-        file_name = image_path.name
 
         for ann_file in self.annotation_files:
             try:
@@ -562,12 +578,8 @@ class COCODataset(Dataset):
 
                 # Build image_id lookup
                 images = data.get("images", [])
-                image_id = None
-
-                for img in images:
-                    if isinstance(img, dict) and img.get("file_name") == file_name:
-                        image_id = img.get("id")
-                        break
+                image_entry = self._match_image_entry(images, image_path)
+                image_id = image_entry.get("id") if image_entry else None
 
                 if image_id is None:
                     continue
@@ -751,7 +763,6 @@ class COCODataset(Dataset):
             Mask array of shape (H, W) with class IDs, or None if
             the image is not found in any annotation file.
         """
-        file_name = image_path.name
         found = False
         offset = 1 if self.has_cat_zero else 0
 
@@ -765,11 +776,7 @@ class COCODataset(Dataset):
 
                 # Find image entry
                 images = data.get("images", [])
-                image_entry = None
-                for img in images:
-                    if isinstance(img, dict) and img.get("file_name") == file_name:
-                        image_entry = img
-                        break
+                image_entry = self._match_image_entry(images, image_path)
 
                 if image_entry is None:
                     continue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1006,6 +1006,77 @@ def coco_mixed_rle_polygon_dataset(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
+def coco_roboflow_rle_dataset(tmp_path: Path) -> Path:
+    """Create a Roboflow-style COCO RLE dataset with path prefixes in file_name.
+
+    Roboflow exports ``file_name`` as ``"images/img001.jpg"`` rather than
+    just ``"img001.jpg"``, and places the annotation JSON alongside the
+    ``images/`` directory inside each split folder.
+
+    Structure:
+        dataset/
+        └── train/
+            ├── _annotations.coco.json   (file_name: "images/img001.jpg")
+            └── images/
+                └── img001.jpg
+    """
+    import cv2 as _cv2
+    import numpy as _np
+
+    dataset_path = tmp_path / "coco_roboflow_rle"
+    dataset_path.mkdir()
+
+    train_dir = dataset_path / "train"
+    train_dir.mkdir()
+
+    counts = []
+    for col in range(10):
+        if col == 0:
+            counts.append(0)
+            counts.append(10)
+        else:
+            counts.append(90)
+            counts.append(10)
+    counts.append(100 * 100 - 10 * 100 + 90)
+
+    coco_data = {
+        "info": {"description": "Roboflow RLE test dataset"},
+        "licenses": [],
+        "images": [
+            {
+                "id": 1,
+                "file_name": "images/img001.jpg",
+                "width": 100,
+                "height": 100,
+            },
+        ],
+        "annotations": [
+            {
+                "id": 1,
+                "image_id": 1,
+                "category_id": 1,
+                "bbox": [0, 0, 10, 10],
+                "segmentation": {"counts": counts, "size": [100, 100]},
+                "area": 100,
+                "iscrowd": 0,
+            },
+        ],
+        "categories": [
+            {"id": 1, "name": "object", "supercategory": "thing"},
+        ],
+    }
+
+    (train_dir / "_annotations.coco.json").write_text(json.dumps(coco_data))
+
+    images_dir = train_dir / "images"
+    images_dir.mkdir()
+    img = _np.random.randint(0, 255, (100, 100, 3), dtype=_np.uint8)
+    _cv2.imwrite(str(images_dir / "img001.jpg"), img)
+
+    return dataset_path
+
+
+@pytest.fixture
 def mask_dataset_dimension_mismatch(tmp_path: Path) -> Path:
     """Create a mask dataset where image and mask have different dimensions.
 

--- a/tests/test_coco_rle.py
+++ b/tests/test_coco_rle.py
@@ -372,6 +372,32 @@ class TestLoadMask:
         assert len(anns[0]["polygon_holes"][0]) == 4  # 4 points for hole
 
 
+class TestRoboflowPathPrefix:
+    """Test matching when file_name contains a path prefix (e.g. 'images/img.jpg')."""
+
+    def test_load_mask_with_path_prefix(self, coco_roboflow_rle_dataset: Path) -> None:
+        dataset = COCODataset.detect(coco_roboflow_rle_dataset)
+        assert dataset is not None
+        image_paths = dataset.get_image_paths()
+        assert len(image_paths) == 1
+
+        mask = dataset.load_mask(image_paths[0])
+        assert mask is not None
+        assert mask.shape == (100, 100)
+        assert (mask[:10, :10] == 1).all()
+
+    def test_get_annotations_with_path_prefix(
+        self, coco_roboflow_rle_dataset: Path
+    ) -> None:
+        dataset = COCODataset.detect(coco_roboflow_rle_dataset)
+        assert dataset is not None
+        image_paths = dataset.get_image_paths()
+
+        anns = dataset.get_annotations_for_image(image_paths[0])
+        assert len(anns) == 1
+        assert anns[0]["class_name"] == "object"
+
+
 class TestGetClassMapping:
     """Test get_class_mapping returns correct category mapping."""
 


### PR DESCRIPTION
Roboflow COCO exports store file_name as "images/img.jpg" instead of just "img.jpg". get_image_paths handled this but load_mask and get_annotations_for_image compared only the basename, causing no annotations to display in the viewer.