### PR TITLE
fix(view): match COCO images when file_name contains a relative path

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1006,12 +1006,13 @@ def coco_mixed_rle_polygon_dataset(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def coco_roboflow_rle_dataset(tmp_path: Path) -> Path:
-    """Create a Roboflow-style COCO RLE dataset with path prefixes in file_name.
+def coco_relative_path_rle_dataset(tmp_path: Path) -> Path:
+    """Create a COCO RLE dataset where file_name contains a relative path prefix.
 
-    Roboflow exports ``file_name`` as ``"images/img001.jpg"`` rather than
-    just ``"img001.jpg"``, and places the annotation JSON alongside the
-    ``images/`` directory inside each split folder.
+    The COCO spec allows ``file_name`` to be a relative path like
+    ``"images/img001.jpg"`` rather than a bare filename. This fixture
+    verifies that ``load_mask`` and ``get_annotations_for_image`` still
+    match correctly.
 
     Structure:
         dataset/

--- a/tests/test_coco_rle.py
+++ b/tests/test_coco_rle.py
@@ -372,11 +372,13 @@ class TestLoadMask:
         assert len(anns[0]["polygon_holes"][0]) == 4  # 4 points for hole
 
 
-class TestRoboflowPathPrefix:
-    """Test matching when file_name contains a path prefix (e.g. 'images/img.jpg')."""
+class TestRelativePathFileNames:
+    """Test matching when file_name contains a relative path (e.g. 'images/img.jpg')."""
 
-    def test_load_mask_with_path_prefix(self, coco_roboflow_rle_dataset: Path) -> None:
-        dataset = COCODataset.detect(coco_roboflow_rle_dataset)
+    def test_load_mask_with_path_prefix(
+        self, coco_relative_path_rle_dataset: Path
+    ) -> None:
+        dataset = COCODataset.detect(coco_relative_path_rle_dataset)
         assert dataset is not None
         image_paths = dataset.get_image_paths()
         assert len(image_paths) == 1
@@ -387,9 +389,9 @@ class TestRoboflowPathPrefix:
         assert (mask[:10, :10] == 1).all()
 
     def test_get_annotations_with_path_prefix(
-        self, coco_roboflow_rle_dataset: Path
+        self, coco_relative_path_rle_dataset: Path
     ) -> None:
-        dataset = COCODataset.detect(coco_roboflow_rle_dataset)
+        dataset = COCODataset.detect(coco_relative_path_rle_dataset)
         assert dataset is not None
         image_paths = dataset.get_image_paths()
 


### PR DESCRIPTION
The COCO spec allows file_name to be a relative path like "images/img.jpg". get_image_paths handled this but load_mask and get_annotations_for_image compared only the basename against the full file_name value, causing no annotations to display in the viewer.