### PR TITLE
feat(convert): add roboflow-coco-rle conversion target

### DIFF
--- a/docs/guides/conversion.md
+++ b/docs/guides/conversion.md
@@ -7,6 +7,7 @@ Use `argus-cv convert` to move between supported segmentation formats.
 - Mask dataset -> YOLO segmentation (`--to yolo-seg`)
 - YOLO segmentation -> COCO (`--to coco`)
 - YOLO segmentation -> Roboflow COCO (`--to roboflow-coco`)
+- YOLO segmentation -> Roboflow COCO RLE (`--to roboflow-coco-rle`)
 
 ## 1. Mask -> YOLO segmentation
 
@@ -30,6 +31,15 @@ argus-cv convert -i /datasets/road_yolo -o /datasets/road_coco --to coco
 ```bash
 argus-cv convert -i /datasets/road_yolo -o /datasets/road_rf_coco --to roboflow-coco
 ```
+
+## 4. YOLO segmentation -> Roboflow COCO RLE
+
+```bash
+argus-cv convert -i /datasets/road_yolo -o /datasets/road_rf_coco_rle --to roboflow-coco-rle
+```
+
+Use this for objects with holes/exclusion zones (donut topology), where
+polygon-ring interpretation can vary across training libraries.
 
 ## Output behavior
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -72,10 +72,11 @@ argus-cv filter -d /datasets/coco -o /datasets/coco_filtered --classes person,ca
 argus-cv convert -i /datasets/masks -o /datasets/yolo_seg --to yolo-seg
 argus-cv convert -i /datasets/yolo_seg -o /datasets/coco --to coco
 argus-cv convert -i /datasets/yolo_seg -o /datasets/rf_coco --to roboflow-coco
+argus-cv convert -i /datasets/yolo_seg -o /datasets/rf_coco_rle --to roboflow-coco-rle
 ```
 
 - `--input-path`, `-i` (default: `.`): source dataset path
 - `--output-path`, `-o` (default: `converted`): output directory
-- `--to` (default: `yolo-seg`): `yolo-seg`, `coco`, or `roboflow-coco`
+- `--to` (default: `yolo-seg`): `yolo-seg`, `coco`, `roboflow-coco`, or `roboflow-coco-rle`
 - `--epsilon-factor`, `-e` (default: `0.005`): polygon simplification for mask -> YOLO
 - `--min-area`, `-a` (default: `100.0`): minimum contour area for mask -> YOLO

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -13,6 +13,7 @@ from argus.core import (
     convert_mask_to_yolo_seg,
     convert_yolo_seg_to_coco,
     convert_yolo_seg_to_roboflow_coco,
+    convert_yolo_seg_to_roboflow_coco_rle,
     filter_coco_dataset,
     filter_mask_dataset,
     filter_yolo_dataset,
@@ -81,3 +82,7 @@ from argus.core import (
 ### `convert_yolo_seg_to_roboflow_coco`
 
 ::: argus.core.convert_yolo_seg_to_roboflow_coco
+
+### `convert_yolo_seg_to_roboflow_coco_rle`
+
+::: argus.core.convert_yolo_seg_to_roboflow_coco_rle

--- a/src/argus/commands/convert_command.py
+++ b/src/argus/commands/convert_command.py
@@ -23,6 +23,7 @@ from argus.core.convert import (
     convert_mask_to_yolo_seg,
     convert_yolo_seg_to_coco,
     convert_yolo_seg_to_roboflow_coco,
+    convert_yolo_seg_to_roboflow_coco_rle,
 )
 
 
@@ -50,7 +51,7 @@ def convert_dataset(
             help=(
                 "Target format: 'yolo-seg' (from mask), "
                 "'coco' (from yolo-seg), or "
-                "'roboflow-coco' (from yolo-seg)."
+                "'roboflow-coco'/'roboflow-coco-rle' (from yolo-seg)."
             ),
         ),
     ] = "yolo-seg",
@@ -80,14 +81,16 @@ def convert_dataset(
     - MaskDataset → YOLO segmentation (--to yolo-seg)
     - YOLO segmentation → COCO (--to coco)
     - YOLO segmentation → Roboflow COCO (--to roboflow-coco)
+    - YOLO segmentation → Roboflow COCO RLE (--to roboflow-coco-rle)
 
     Examples:
         uvx argus-cv convert -i /path/to/masks -o /path/to/output --to yolo-seg
         uvx argus-cv convert -i /path/to/yolo -o /path/to/output --to coco
         uvx argus-cv convert -i /path/to/yolo -o /path/to/output --to roboflow-coco
+        uvx argus-cv convert -i /path/to/yolo -o /path/to/output --to roboflow-coco-rle
     """
     # Validate format
-    supported_formats = ("yolo-seg", "coco", "roboflow-coco")
+    supported_formats = ("yolo-seg", "coco", "roboflow-coco", "roboflow-coco-rle")
     if to_format not in supported_formats:
         console.print(
             f"[red]Error: Unsupported target format '{to_format}'.[/red]\n"
@@ -102,9 +105,26 @@ def convert_dataset(
     if to_format == "yolo-seg":
         _convert_mask_to_yolo(input_path, output_path, epsilon_factor, min_area)
     elif to_format == "coco":
-        _convert_yolo_to_coco(input_path, output_path, roboflow_layout=False)
+        _convert_yolo_to_coco(
+            input_path,
+            output_path,
+            roboflow_layout=False,
+            use_rle=False,
+        )
     elif to_format == "roboflow-coco":
-        _convert_yolo_to_coco(input_path, output_path, roboflow_layout=True)
+        _convert_yolo_to_coco(
+            input_path,
+            output_path,
+            roboflow_layout=True,
+            use_rle=False,
+        )
+    elif to_format == "roboflow-coco-rle":
+        _convert_yolo_to_coco(
+            input_path,
+            output_path,
+            roboflow_layout=True,
+            use_rle=True,
+        )
 
 
 def _convert_mask_to_yolo(
@@ -172,7 +192,10 @@ def _convert_mask_to_yolo(
 
 
 def _convert_yolo_to_coco(
-    input_path: Path, output_path: Path, roboflow_layout: bool
+    input_path: Path,
+    output_path: Path,
+    roboflow_layout: bool,
+    use_rle: bool = False,
 ) -> None:
     """Run YOLO-seg → COCO conversion."""
     from argus.core.base import TaskType
@@ -194,7 +217,12 @@ def _convert_yolo_to_coco(
         )
         raise typer.Exit(1)
 
-    target_name = "Roboflow COCO" if roboflow_layout else "COCO"
+    if roboflow_layout and use_rle:
+        target_name = "Roboflow COCO RLE"
+    elif roboflow_layout:
+        target_name = "Roboflow COCO"
+    else:
+        target_name = "COCO"
     console.print(f"[cyan]Converting YOLO segmentation to {target_name} format[/cyan]")
     console.print(f"  Source: {input_path}")
     console.print(f"  Output: {output_path}")
@@ -216,7 +244,13 @@ def _convert_yolo_to_coco(
             progress.update(task, completed=current, total=total)
 
         try:
-            if roboflow_layout:
+            if roboflow_layout and use_rle:
+                stats = convert_yolo_seg_to_roboflow_coco_rle(
+                    dataset=yolo_dataset,
+                    output_path=output_path,
+                    progress_callback=update_progress,
+                )
+            elif roboflow_layout:
                 stats = convert_yolo_seg_to_roboflow_coco(
                     dataset=yolo_dataset,
                     output_path=output_path,

--- a/src/argus/core/__init__.py
+++ b/src/argus/core/__init__.py
@@ -9,6 +9,7 @@ from argus.core.convert import (
     convert_mask_to_yolo_seg,
     convert_yolo_seg_to_coco,
     convert_yolo_seg_to_roboflow_coco,
+    convert_yolo_seg_to_roboflow_coco_rle,
     mask_to_polygons,
 )
 from argus.core.filter import (
@@ -39,4 +40,5 @@ __all__ = [
     "convert_mask_to_yolo_seg",
     "convert_yolo_seg_to_coco",
     "convert_yolo_seg_to_roboflow_coco",
+    "convert_yolo_seg_to_roboflow_coco_rle",
 ]

--- a/src/argus/core/convert.py
+++ b/src/argus/core/convert.py
@@ -396,11 +396,92 @@ def _yolo_polygon_to_coco_segmentation(
     return segmentation, bbox, area
 
 
+def _binary_mask_to_coco_rle(mask: NDArray[np.uint8]) -> dict[str, list[int]]:
+    """Encode a binary mask to COCO uncompressed RLE.
+
+    Uses COCO's column-major (Fortran-order) flattening and run lengths starting
+    with the background count.
+
+    Args:
+        mask: Binary mask with shape (H, W), foreground as non-zero.
+
+    Returns:
+        RLE dict with ``size`` and ``counts``.
+    """
+    height, width = mask.shape[:2]
+    flat = (mask > 0).astype(np.uint8).reshape(-1, order="F")
+
+    counts: list[int] = []
+    current_value = 0
+    run_length = 0
+    for value in flat:
+        v = int(value)
+        if v == current_value:
+            run_length += 1
+        else:
+            counts.append(run_length)
+            run_length = 1
+            current_value = v
+    counts.append(run_length)
+
+    return {"size": [height, width], "counts": counts}
+
+
+def _yolo_polygon_to_coco_rle(
+    points: list[tuple[float, float]],
+    img_width: int,
+    img_height: int,
+) -> tuple[dict[str, list[int]], list[float], float]:
+    """Convert a YOLO polygon to COCO RLE, preserving donut holes.
+
+    The input polygon may contain bridge-connected donut geometry. We first
+    recover ring structure via ``_yolo_polygon_to_coco_segmentation`` and then
+    rasterize all rings in one ``fillPoly`` call so OpenCV's even-odd filling
+    cuts out holes.
+
+    Args:
+        points: Normalized (x, y) coordinate pairs from YOLO annotation.
+        img_width: Image width in pixels.
+        img_height: Image height in pixels.
+
+    Returns:
+        Tuple of (rle, bbox, area).
+    """
+    segmentation, _, _ = _yolo_polygon_to_coco_segmentation(
+        points, img_width, img_height
+    )
+    mask = np.zeros((img_height, img_width), dtype=np.uint8)
+
+    rings: list[np.ndarray] = []
+    for ring in segmentation:
+        if len(ring) < 6:
+            continue
+        pts = np.array(ring, dtype=np.int32).reshape(-1, 2)
+        if len(pts) >= 3:
+            rings.append(pts)
+
+    if rings:
+        cv2.fillPoly(mask, rings, 1)
+
+    area = float(np.count_nonzero(mask))
+    if area == 0.0:
+        return _binary_mask_to_coco_rle(mask), [0.0, 0.0, 0.0, 0.0], 0.0
+
+    rows = np.any(mask, axis=1)
+    cols = np.any(mask, axis=0)
+    rmin, rmax = np.where(rows)[0][[0, -1]]
+    cmin, cmax = np.where(cols)[0][[0, -1]]
+    bbox = [float(cmin), float(rmin), float(cmax - cmin + 1), float(rmax - rmin + 1)]
+
+    return _binary_mask_to_coco_rle(mask), bbox, area
+
+
 def _convert_yolo_seg_to_coco_layout(
     dataset: "YOLODataset",  # noqa: F821
     output_path: Path,
     progress_callback: Callable[[int, int], None] | None = None,
     roboflow_layout: bool = False,
+    segmentation_format: str = "polygon",
 ) -> dict[str, int]:
     """Convert a YOLO segmentation dataset to COCO-compatible JSON outputs.
 
@@ -409,6 +490,7 @@ def _convert_yolo_seg_to_coco_layout(
         output_path: Output directory for converted dataset.
         progress_callback: Optional callback(current, total) for progress updates.
         roboflow_layout: If True, write Roboflow COCO layout.
+        segmentation_format: ``polygon`` or ``rle`` for COCO ``segmentation``.
 
     Returns:
         Dictionary with conversion statistics:
@@ -423,6 +505,11 @@ def _convert_yolo_seg_to_coco_layout(
         "skipped": 0,
         "warnings": 0,
     }
+    if segmentation_format not in ("polygon", "rle"):
+        raise ValueError(
+            "segmentation_format must be 'polygon' or 'rle', "
+            f"got '{segmentation_format}'."
+        )
 
     output_path.mkdir(parents=True, exist_ok=True)
 
@@ -507,11 +594,17 @@ def _convert_yolo_seg_to_coco_layout(
                 annotations_data = _parse_yolo_label_file(label_path)
 
                 for class_id, points in annotations_data:
-                    segmentation, bbox, area = _yolo_polygon_to_coco_segmentation(
-                        points, img_width, img_height
-                    )
+                    if segmentation_format == "rle":
+                        segmentation: list[list[float]] | dict[str, list[int]]
+                        segmentation, bbox, area = _yolo_polygon_to_coco_rle(
+                            points, img_width, img_height
+                        )
+                    else:
+                        segmentation, bbox, area = _yolo_polygon_to_coco_segmentation(
+                            points, img_width, img_height
+                        )
 
-                    if not segmentation:
+                    if area == 0.0:
                         stats["warnings"] += 1
                         continue
 
@@ -566,6 +659,7 @@ def convert_yolo_seg_to_coco(
         output_path=output_path,
         progress_callback=progress_callback,
         roboflow_layout=False,
+        segmentation_format="polygon",
     )
 
 
@@ -587,4 +681,27 @@ def convert_yolo_seg_to_roboflow_coco(
         output_path=output_path,
         progress_callback=progress_callback,
         roboflow_layout=True,
+        segmentation_format="polygon",
+    )
+
+
+def convert_yolo_seg_to_roboflow_coco_rle(
+    dataset: "YOLODataset",  # noqa: F821
+    output_path: Path,
+    progress_callback: Callable[[int, int], None] | None = None,
+) -> dict[str, int]:
+    """Convert a YOLO segmentation dataset to Roboflow COCO layout with RLE.
+
+    Output structure:
+        output/
+        ├── train/_annotations.coco.json
+        ├── valid/_annotations.coco.json
+        └── test/_annotations.coco.json
+    """
+    return _convert_yolo_seg_to_coco_layout(
+        dataset=dataset,
+        output_path=output_path,
+        progress_callback=progress_callback,
+        roboflow_layout=True,
+        segmentation_format="rle",
     )

--- a/tests/test_convert_yolo_to_coco.py
+++ b/tests/test_convert_yolo_to_coco.py
@@ -15,10 +15,27 @@ from argus.core.convert import (
     _yolo_polygon_to_coco_segmentation,
     convert_yolo_seg_to_coco,
     convert_yolo_seg_to_roboflow_coco,
+    convert_yolo_seg_to_roboflow_coco_rle,
 )
 from argus.core.yolo import YOLODataset
 
 runner = CliRunner()
+
+
+def _decode_uncompressed_rle(segmentation: dict) -> np.ndarray:
+    """Decode COCO uncompressed RLE to a binary mask."""
+    height, width = segmentation["size"]
+    counts = segmentation["counts"]
+
+    flat = np.zeros(height * width, dtype=np.uint8)
+    pos = 0
+    for i, count in enumerate(counts):
+        end = min(pos + int(count), flat.size)
+        if i % 2 == 1 and end > pos:
+            flat[pos:end] = 1
+        pos += int(count)
+
+    return flat.reshape((height, width), order="F")
 
 
 # ---------------------------------------------------------------------------
@@ -497,6 +514,69 @@ class TestConvertYoloSegToRoboflowCoco:
         assert len(list((output / "train").glob("*.jpg"))) == 2
 
 
+class TestConvertYoloSegToRoboflowCocoRle:
+    """Tests for Roboflow COCO RLE layout conversion."""
+
+    def test_output_structure(self, yolo_seg_dataset: Path, tmp_path: Path) -> None:
+        dataset = YOLODataset.detect(yolo_seg_dataset)
+        assert dataset is not None
+
+        output = tmp_path / "roboflow_coco_rle_out"
+        stats = convert_yolo_seg_to_roboflow_coco_rle(dataset, output)
+
+        # train + valid split directories with colocated annotations
+        assert (output / "train").is_dir()
+        assert (output / "valid").is_dir()
+        assert (output / "train" / "_annotations.coco.json").exists()
+        assert (output / "valid" / "_annotations.coco.json").exists()
+
+        # Images are copied directly into split dirs in Roboflow format
+        assert len(list((output / "train").glob("*.jpg"))) == 2
+        assert len(list((output / "valid").glob("*.jpg"))) == 1
+
+        # Standard COCO layout directories should not be required here
+        assert not (output / "annotations").exists()
+        assert not (output / "images").exists()
+
+        # Stats should match regular converter
+        assert stats["images"] == 3
+        assert stats["annotations"] == 4
+
+        with open(output / "train" / "_annotations.coco.json") as f:
+            coco = json.load(f)
+        for ann in coco["annotations"]:
+            seg = ann["segmentation"]
+            assert isinstance(seg, dict)
+            assert "size" in seg
+            assert "counts" in seg
+            assert isinstance(seg["counts"], list)
+
+    def test_donut_hole_preserved(
+        self, yolo_seg_donut_dataset: Path, tmp_path: Path
+    ) -> None:
+        dataset = YOLODataset.detect(yolo_seg_donut_dataset)
+        assert dataset is not None
+
+        output = tmp_path / "roboflow_coco_rle_out"
+        stats = convert_yolo_seg_to_roboflow_coco_rle(dataset, output)
+
+        assert stats["images"] == 1
+        assert stats["annotations"] == 1
+
+        with open(output / "train" / "_annotations.coco.json") as f:
+            coco = json.load(f)
+
+        ann = coco["annotations"][0]
+        mask = _decode_uncompressed_rle(ann["segmentation"])
+        contours, hierarchy = cv2.findContours(
+            (mask * 255).astype(np.uint8), cv2.RETR_CCOMP, cv2.CHAIN_APPROX_SIMPLE
+        )
+        assert len(contours) > 0
+        assert hierarchy is not None
+        hole_count = sum(1 for h in hierarchy[0] if h[3] != -1)
+        assert hole_count >= 1
+
+
 class TestConvertYoloSegToCocoEmptyLabels:
     """Tests for images with no annotations."""
 
@@ -682,3 +762,37 @@ class TestConvertCliRoboflowCoco:
         assert "Annotations created" in result.stdout
         assert (output / "train" / "_annotations.coco.json").exists()
         assert (output / "valid" / "_annotations.coco.json").exists()
+
+
+class TestConvertCliRoboflowCocoRle:
+    """CLI end-to-end tests for --to roboflow-coco-rle."""
+
+    def test_convert_to_roboflow_coco_rle_basic(
+        self, yolo_seg_dataset: Path, tmp_path: Path
+    ) -> None:
+        output = tmp_path / "rf_coco_rle_out"
+        result = runner.invoke(
+            app,
+            [
+                "convert",
+                "-i",
+                str(yolo_seg_dataset),
+                "-o",
+                str(output),
+                "--to",
+                "roboflow-coco-rle",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Conversion complete" in result.stdout
+        assert "Images processed" in result.stdout
+        assert "Annotations created" in result.stdout
+
+        ann_file = output / "train" / "_annotations.coco.json"
+        assert ann_file.exists()
+        with open(ann_file) as f:
+            coco = json.load(f)
+
+        assert len(coco["annotations"]) > 0
+        assert isinstance(coco["annotations"][0]["segmentation"], dict)


### PR DESCRIPTION
## Summary
- add YOLO-seg to Roboflow COCO RLE conversion path (`--to roboflow-coco-rle`)
- implement native COCO uncompressed RLE encoding in converter
- preserve donut/hole topology by rasterizing recovered rings with even-odd fill before RLE encoding
- expose `convert_yolo_seg_to_roboflow_coco_rle` in `argus.core`
- update conversion CLI/docs and Python API docs
- add unit/integration/CLI coverage for the new format, including hole-preservation checks

## Validation
- `uv run ruff check src/argus/core/convert.py src/argus/core/__init__.py src/argus/commands/convert_command.py tests/test_convert_yolo_to_coco.py`
- `uv run pytest tests/test_convert_yolo_to_coco.py tests/test_convert.py -q`
