### PR TITLE
fix(cli): make unsplit dataset path positional

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -45,7 +45,7 @@ split.
 ## 5. Merge split dataset back to unsplit (optional)
 
 ```bash
-argus-cv unsplit -d /datasets/traffic_splits -o /datasets/traffic_unsplit
+argus-cv unsplit /datasets/traffic_splits -o /datasets/traffic_unsplit
 ```
 
 ## 6. Convert formats (optional)

--- a/docs/guides/splitting.md
+++ b/docs/guides/splitting.md
@@ -28,14 +28,14 @@ argus-cv split /datasets/animals -o /datasets/animals_splits --seed 7
 ## Merge back to unsplit
 
 ```bash
-argus-cv unsplit -d /datasets/animals_splits -o /datasets/animals_unsplit
+argus-cv unsplit /datasets/animals_splits -o /datasets/animals_unsplit
 ```
 
 If your split directories contain duplicate filenames, choose a collision
 strategy:
 
 ```bash
-argus-cv unsplit -d /datasets/animals_splits -o /datasets/animals_unsplit --collision-policy prefix-split
+argus-cv unsplit /datasets/animals_splits -o /datasets/animals_unsplit --collision-policy prefix-split
 ```
 
 `--collision-policy` options:

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,7 +74,7 @@ argus-cv convert -i /data/animals_masks -o /data/animals_yolo --to yolo-seg
 === "Merge splits"
 
     ```bash
-    argus-cv unsplit -d /datasets/retail_splits -o /datasets/retail_unsplit
+    argus-cv unsplit /datasets/retail_splits -o /datasets/retail_unsplit
     ```
 
 === "Convert formats"

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -58,10 +58,10 @@ argus-cv split /datasets/animals -o /datasets/animals_splits -r 0.8,0.1,0.1 --se
 ## unsplit
 
 ```bash
-argus-cv unsplit -d /datasets/animals_splits -o /datasets/animals_unsplit --collision-policy prefix-split
+argus-cv unsplit /datasets/animals_splits -o /datasets/animals_unsplit --collision-policy prefix-split
 ```
 
-- `--dataset-path`, `-d` (default: `.`): split dataset root (YOLO, COCO, or mask)
+- `DATASET` (default: `.`): split dataset root (YOLO, COCO, or mask)
 - `--output-path`, `-o` (default: `unsplit`): output directory
 - `--collision-policy` (default: `error`): `error`, `prefix-split`, or `hash`
 

--- a/src/argus/commands/unsplit_command.py
+++ b/src/argus/commands/unsplit_command.py
@@ -20,14 +20,16 @@ from argus.discovery import _detect_dataset
 
 
 def unsplit_dataset(
-    dataset_path: Annotated[
-        Path,
-        typer.Option(
-            "--dataset-path",
-            "-d",
-            help="Path to the split dataset root directory.",
+    dataset: Annotated[
+        Path | None,
+        typer.Argument(
+            help=(
+                "Path to the split dataset root directory. "
+                "Defaults to the current directory."
+            ),
+            show_default=False,
         ),
-    ] = Path("."),
+    ] = None,
     output_path: Annotated[
         Path,
         typer.Option(
@@ -46,7 +48,7 @@ def unsplit_dataset(
     ] = "error",
 ) -> None:
     """Merge a split dataset into an unsplit dataset."""
-    dataset_path = _resolve_existing_directory(dataset_path)
+    dataset_path = _resolve_existing_directory(dataset or Path("."))
 
     dataset = _detect_dataset(dataset_path)
     if not dataset:

--- a/tests/test_split_command.py
+++ b/tests/test_split_command.py
@@ -360,7 +360,6 @@ def test_unsplit_command_yolo(tmp_path: Path, yolo_detection_dataset: Path) -> N
         app,
         [
             "unsplit",
-            "--dataset-path",
             str(yolo_detection_dataset),
             "--output-path",
             str(output_path),
@@ -378,7 +377,6 @@ def test_unsplit_command_coco(tmp_path: Path, coco_detection_dataset: Path) -> N
         app,
         [
             "unsplit",
-            "--dataset-path",
             str(coco_detection_dataset),
             "--output-path",
             str(output_path),
@@ -395,7 +393,6 @@ def test_unsplit_command_mask(tmp_path: Path, mask_dataset_grayscale: Path) -> N
         app,
         [
             "unsplit",
-            "--dataset-path",
             str(mask_dataset_grayscale),
             "--output-path",
             str(output_path),
@@ -415,7 +412,6 @@ def test_unsplit_command_rejects_unsplit_dataset(
         app,
         [
             "unsplit",
-            "--dataset-path",
             str(yolo_flat_structure_dataset),
             "--output-path",
             str(output_path),
@@ -434,7 +430,6 @@ def test_unsplit_command_collision_policy_prefix_split(
         app,
         [
             "unsplit",
-            "--dataset-path",
             str(yolo_classification_dataset),
             "--output-path",
             str(output_path),
@@ -447,6 +442,38 @@ def test_unsplit_command_collision_policy_prefix_split(
     cat_files = sorted(p.name for p in (output_path / "cat").glob("*.jpg"))
     assert "img001.jpg" in cat_files
     assert "val_img001.jpg" in cat_files
+
+
+def test_unsplit_command_rejects_removed_dataset_option(tmp_path: Path) -> None:
+    """Test unsplit command no longer accepts --dataset-path."""
+    dataset_path = tmp_path / "yolo_split_removed_option"
+    _create_unsplit_yolo_dataset(dataset_path)
+    split_output = tmp_path / "yolo_split_removed_option_splits"
+
+    split_result = runner.invoke(
+        app,
+        [
+            "split",
+            str(dataset_path),
+            "--output-path",
+            str(split_output),
+        ],
+    )
+    assert split_result.exit_code == 0
+
+    result = runner.invoke(
+        app,
+        [
+            "unsplit",
+            "--dataset-path",
+            str(split_output),
+        ],
+    )
+    help_result = runner.invoke(app, ["unsplit", "--help"])
+
+    assert result.exit_code == 2
+    assert help_result.exit_code == 0
+    assert "--dataset-path" not in strip_ansi(help_result.output)
 
 
 def test_is_coco_unsplit_rejects_roboflow_split_dataset(


### PR DESCRIPTION
## Summary
- switch `argus-cv unsplit` from the removed `--dataset-path/-d` option to the positional dataset argument
- update the unsplit CLI tests to use the positional path and add a regression test for the removed option
- refresh CLI and guide examples that still showed the old `-d` usage

## Testing
- `uv run pytest tests/test_split_command.py -k unsplit`