### PR TITLE
fix(cli): normalize relative output path resolution

### DIFF
--- a/docs/guides/conversion.md
+++ b/docs/guides/conversion.md
@@ -44,7 +44,7 @@ polygon-ring interpretation can vary across training libraries.
 ## Output behavior
 
 - Output directory must be empty or not exist.
-- Relative output paths are resolved next to the input dataset directory.
+- Relative output paths are resolved under the input dataset root.
 - Argus keeps dataset splits when they exist.
 
 ## Common errors

--- a/docs/guides/filtering.md
+++ b/docs/guides/filtering.md
@@ -2,6 +2,10 @@
 
 Use `argus-cv filter` to create a filtered copy of a dataset containing only specified classes.
 
+Relative output paths are resolved under the dataset root. For example,
+`argus-cv filter /datasets/coco -o filtered --classes person` writes to
+`/datasets/coco/filtered`.
+
 ## Basic usage
 
 ```bash

--- a/docs/guides/splitting.md
+++ b/docs/guides/splitting.md
@@ -3,6 +3,10 @@
 Use `argus-cv split` to create train/val/test splits from an unsplit dataset,
 and `argus-cv unsplit` to merge split datasets back into a flat layout.
 
+Relative output paths are resolved under the dataset root. For example,
+`argus-cv split /datasets/animals -o splits` writes to
+`/datasets/animals/splits`.
+
 ## Basic split
 
 ```bash

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -51,7 +51,7 @@ argus-cv split /datasets/animals -o /datasets/animals_splits -r 0.8,0.1,0.1 --se
 ```
 
 - `DATASET` (default: `.`): unsplit dataset root (YOLO, COCO, or mask)
-- `--output-path`, `-o` (default: `splits`): output directory
+- `--output-path`, `-o` (default: `splits`): output directory; relative paths resolve under `DATASET`
 - `--ratio`, `-r` (default: `0.8,0.1,0.1`): train/val/test ratio
 - `--seed` (default: `42`): random seed
 
@@ -62,7 +62,7 @@ argus-cv unsplit /datasets/animals_splits -o /datasets/animals_unsplit --collisi
 ```
 
 - `DATASET` (default: `.`): split dataset root (YOLO, COCO, or mask)
-- `--output-path`, `-o` (default: `unsplit`): output directory
+- `--output-path`, `-o` (default: `unsplit`): output directory; relative paths resolve under `DATASET`
 - `--collision-policy` (default: `error`): `error`, `prefix-split`, or `hash`
 
 ## filter
@@ -72,7 +72,7 @@ argus-cv filter /datasets/coco -o /datasets/coco_filtered --classes person,car -
 ```
 
 - `DATASET` (default: `.`): source dataset root
-- `--output`, `-o` (default: `filtered`): output directory
+- `--output`, `-o` (default: `filtered`): output directory; relative paths resolve under `DATASET`
 - `--classes`, `-c` (required): comma-separated classes to keep
 - `--no-background`: drop images with no labels after filtering
 - `--symlinks`: symlink images instead of copying
@@ -87,7 +87,7 @@ argus-cv convert -i /datasets/yolo_seg -o /datasets/rf_coco_rle --to roboflow-co
 ```
 
 - `--input-path`, `-i` (default: `.`): source dataset path
-- `--output-path`, `-o` (default: `converted`): output directory
+- `--output-path`, `-o` (default: `converted`): output directory; relative paths resolve under `--input-path`
 - `--to` (default: `yolo-seg`): `yolo-seg`, `coco`, `roboflow-coco`, or `roboflow-coco-rle`
 - `--epsilon-factor`, `-e` (default: `0.005`): polygon simplification for mask -> YOLO
 - `--min-area`, `-a` (default: `100.0`): minimum contour area for mask -> YOLO

--- a/src/argus/commands/_utils.py
+++ b/src/argus/commands/_utils.py
@@ -20,7 +20,7 @@ def _resolve_existing_directory(path: Path) -> Path:
 
 
 def _resolve_output_path(output_path: Path, base_path: Path) -> Path:
-    """Resolve output path relative to a base path when needed."""
+    """Resolve an output path relative to a command-specific dataset root."""
     if not output_path.is_absolute():
         output_path = base_path / output_path
     return output_path.resolve()

--- a/src/argus/commands/convert_command.py
+++ b/src/argus/commands/convert_command.py
@@ -41,7 +41,10 @@ def convert_dataset(
         typer.Option(
             "--output-path",
             "-o",
-            help="Output directory for converted dataset.",
+            help=(
+                "Output directory for converted dataset. Relative paths resolve "
+                "under the input dataset root."
+            ),
         ),
     ] = Path("converted"),
     to_format: Annotated[
@@ -99,7 +102,7 @@ def convert_dataset(
         raise typer.Exit(1)
 
     input_path = _resolve_existing_directory(input_path)
-    output_path = _resolve_output_path(output_path, input_path.parent)
+    output_path = _resolve_output_path(output_path, input_path)
     _ensure_output_directory_empty(output_path)
 
     if to_format == "yolo-seg":

--- a/src/argus/commands/filter_command.py
+++ b/src/argus/commands/filter_command.py
@@ -43,7 +43,10 @@ def filter_dataset(
         typer.Option(
             "--output",
             "-o",
-            help="Output directory for filtered dataset.",
+            help=(
+                "Output directory for filtered dataset. Relative paths resolve "
+                "under the dataset root."
+            ),
         ),
     ] = Path("filtered"),
     classes: Annotated[
@@ -116,7 +119,7 @@ def filter_dataset(
         )
         raise typer.Exit(1)
 
-    output_path = _resolve_output_path(output_path, dataset_path.parent)
+    output_path = _resolve_output_path(output_path, dataset_path)
     _ensure_output_directory_empty(output_path)
 
     # Show filter info

--- a/src/argus/commands/split_command.py
+++ b/src/argus/commands/split_command.py
@@ -7,7 +7,7 @@ import typer
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from argus.cli_common import console
-from argus.commands._utils import _resolve_existing_directory
+from argus.commands._utils import _resolve_existing_directory, _resolve_output_path
 from argus.core import COCODataset, MaskDataset, YOLODataset
 from argus.core.base import Partitioning
 from argus.core.split import (
@@ -34,7 +34,10 @@ def split_dataset(
         typer.Option(
             "--output-path",
             "-o",
-            help="Directory to write the split dataset.",
+            help=(
+                "Directory to write the split dataset. Relative paths resolve "
+                "under the dataset root."
+            ),
         ),
     ] = Path("splits"),
     ratio: Annotated[
@@ -72,9 +75,7 @@ def split_dataset(
         console.print(f"[red]Error: {exc}[/red]")
         raise typer.Exit(1) from exc
 
-    if not output_path.is_absolute():
-        output_path = dataset_path / output_path
-    output_path = output_path.resolve()
+    output_path = _resolve_output_path(output_path, dataset_path)
 
     if detected_dataset.partitioning == Partitioning.SPLIT:
         console.print(

--- a/src/argus/commands/unsplit_command.py
+++ b/src/argus/commands/unsplit_command.py
@@ -7,7 +7,7 @@ import typer
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from argus.cli_common import console
-from argus.commands._utils import _resolve_existing_directory
+from argus.commands._utils import _resolve_existing_directory, _resolve_output_path
 from argus.core import COCODataset, MaskDataset, YOLODataset
 from argus.core.base import Partitioning
 from argus.core.split import (
@@ -35,7 +35,10 @@ def unsplit_dataset(
         typer.Option(
             "--output-path",
             "-o",
-            help="Directory to write the unsplit dataset.",
+            help=(
+                "Directory to write the unsplit dataset. Relative paths resolve "
+                "under the dataset root."
+            ),
         ),
     ] = Path("unsplit"),
     collision_policy: Annotated[
@@ -76,9 +79,7 @@ def unsplit_dataset(
         raise typer.Exit(1)
     typed_policy = cast(CollisionPolicy, collision_policy)
 
-    if not output_path.is_absolute():
-        output_path = dataset_path / output_path
-    output_path = output_path.resolve()
+    output_path = _resolve_output_path(output_path, dataset_path)
 
     if isinstance(dataset, YOLODataset):
         with Progress(

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -332,6 +332,69 @@ class TestConvertCLI:
         assert "Conversion complete" in result.stdout
         assert output_path.exists()
 
+    def test_convert_command_resolves_relative_output_under_dataset_root(
+        self, mask_dataset_grayscale: Path
+    ) -> None:
+        """Test convert command resolves relative output paths under the input."""
+        result = runner.invoke(
+            app,
+            [
+                "convert",
+                "-i",
+                str(mask_dataset_grayscale),
+                "-o",
+                "converted_out",
+                "--to",
+                "yolo-seg",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert (mask_dataset_grayscale / "converted_out" / "data.yaml").exists()
+        assert not (mask_dataset_grayscale.parent / "converted_out").exists()
+
+    def test_convert_command_uses_dataset_root_for_default_output(
+        self, mask_dataset_grayscale: Path
+    ) -> None:
+        """Test convert command writes the default output under the input."""
+        result = runner.invoke(
+            app,
+            [
+                "convert",
+                "-i",
+                str(mask_dataset_grayscale),
+                "--to",
+                "yolo-seg",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert (mask_dataset_grayscale / "converted" / "data.yaml").exists()
+        assert not (mask_dataset_grayscale.parent / "converted").exists()
+
+    def test_convert_command_absolute_output_stays_absolute(
+        self, mask_dataset_grayscale: Path, tmp_path: Path
+    ) -> None:
+        """Test convert command does not re-anchor absolute output paths."""
+        output_path = tmp_path / "absolute_converted"
+
+        result = runner.invoke(
+            app,
+            [
+                "convert",
+                "-i",
+                str(mask_dataset_grayscale),
+                "-o",
+                str(output_path),
+                "--to",
+                "yolo-seg",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert (output_path / "data.yaml").exists()
+        assert not (mask_dataset_grayscale / "absolute_converted").exists()
+
     def test_convert_command_with_params(
         self, mask_dataset_grayscale: Path, tmp_path: Path
     ) -> None:

--- a/tests/test_filter_command.py
+++ b/tests/test_filter_command.py
@@ -528,6 +528,73 @@ def test_filter_command_yolo(tmp_path: Path) -> None:
     assert (output_path / "data.yaml").exists()
 
 
+def test_filter_command_resolves_relative_output_under_dataset_root(
+    tmp_path: Path,
+) -> None:
+    """Test filter CLI command resolves relative output paths under the dataset."""
+    dataset_path = tmp_path / "yolo_det_relative_output"
+    _create_yolo_detection_dataset(dataset_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "filter",
+            str(dataset_path),
+            "--output",
+            "filtered_out",
+            "--classes",
+            "ball",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert (dataset_path / "filtered_out" / "data.yaml").exists()
+    assert not (tmp_path / "filtered_out").exists()
+
+
+def test_filter_command_uses_dataset_root_for_default_output(tmp_path: Path) -> None:
+    """Test filter CLI command writes the default output under the dataset."""
+    dataset_path = tmp_path / "yolo_det_default_output"
+    _create_yolo_detection_dataset(dataset_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "filter",
+            str(dataset_path),
+            "--classes",
+            "ball",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert (dataset_path / "filtered" / "data.yaml").exists()
+    assert not (tmp_path / "filtered").exists()
+
+
+def test_filter_command_absolute_output_stays_absolute(tmp_path: Path) -> None:
+    """Test filter CLI command does not re-anchor absolute output paths."""
+    dataset_path = tmp_path / "yolo_det_absolute_output"
+    _create_yolo_detection_dataset(dataset_path)
+
+    output_path = tmp_path / "absolute_filtered"
+    result = runner.invoke(
+        app,
+        [
+            "filter",
+            str(dataset_path),
+            "--output",
+            str(output_path),
+            "--classes",
+            "ball",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert (output_path / "data.yaml").exists()
+    assert not (dataset_path / "absolute_filtered").exists()
+
+
 def test_filter_command_coco(tmp_path: Path) -> None:
     """Test filter CLI command with COCO dataset."""
     dataset_path = tmp_path / "coco"

--- a/tests/test_split_command.py
+++ b/tests/test_split_command.py
@@ -226,6 +226,27 @@ def test_split_command_accepts_positional_dataset(tmp_path: Path) -> None:
     assert (output_path / "labels" / "train").is_dir()
 
 
+def test_split_command_resolves_relative_output_under_dataset_root(
+    tmp_path: Path,
+) -> None:
+    dataset_path = tmp_path / "yolo_unsplit_relative_output"
+    _create_unsplit_yolo_dataset(dataset_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "split",
+            str(dataset_path),
+            "--output-path",
+            "splits_out",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert (dataset_path / "splits_out" / "images" / "train").is_dir()
+    assert not (tmp_path / "splits_out").exists()
+
+
 def test_split_command_rejects_existing_splits(yolo_detection_dataset: Path) -> None:
     output_path = yolo_detection_dataset / "output"
     result = runner.invoke(
@@ -369,6 +390,24 @@ def test_unsplit_command_yolo(tmp_path: Path, yolo_detection_dataset: Path) -> N
     assert result.exit_code == 0
     assert (output_path / "images" / "img001.jpg").exists()
     assert (output_path / "labels" / "img001.txt").exists()
+
+
+def test_unsplit_command_resolves_relative_output_under_dataset_root(
+    yolo_detection_dataset: Path,
+) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "unsplit",
+            str(yolo_detection_dataset),
+            "--output-path",
+            "unsplit_out",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert (yolo_detection_dataset / "unsplit_out" / "images" / "img001.jpg").exists()
+    assert not (yolo_detection_dataset.parent / "unsplit_out").exists()
 
 
 def test_unsplit_command_coco(tmp_path: Path, coco_detection_dataset: Path) -> None:


### PR DESCRIPTION
## Summary
- resolve relative output paths for split, unsplit, filter, and convert from the dataset root
- update CLI help text and docs to describe the normalized output behavior
- add regression tests for relative, default, and absolute output paths

## Testing
- uv run pytest tests/test_split_command.py tests/test_filter_command.py tests/test_convert.py -q
- uv run ruff check src/argus/commands/_utils.py src/argus/commands/split_command.py src/argus/commands/unsplit_command.py src/argus/commands/filter_command.py src/argus/commands/convert_command.py tests/test_split_command.py tests/test_filter_command.py tests/test_convert.py